### PR TITLE
Draft di

### DIFF
--- a/Assets/ulox/Runtime/Compiler/Compiler.cs
+++ b/Assets/ulox/Runtime/Compiler/Compiler.cs
@@ -19,7 +19,12 @@
                 _testdec,
                 _classCompiler,
                 _testcaseCompilette,
-                _buildCompilette);
+                _buildCompilette
+                );
+
+            this.AddStatementCompilettes(
+                new CompiletteAction(TokenType.REGISTER, RegisterStatement)
+                );
 
             this.SetPrattRules(
                 (TokenType.DOT, new ParseRule(null, this.Dot, Precedence.Call)),
@@ -27,8 +32,20 @@
                 (TokenType.SUPER, new ParseRule(Super, null, Precedence.None)),
                 (TokenType.CONTEXT_NAME_CLASS, new ParseRule(CName, null, Precedence.None)),
                 (TokenType.CONTEXT_NAME_TESTCASE, new ParseRule(TCName, null, Precedence.None)),
-                (TokenType.CONTEXT_NAME_TESTSET, new ParseRule(TSName, null, Precedence.None))
-                              );
+                (TokenType.CONTEXT_NAME_TESTSET, new ParseRule(TSName, null, Precedence.None)),
+                (TokenType.INJECT, new ParseRule(Inject, null, Precedence.Term))
+                );
+        }
+
+
+
+        private void RegisterStatement(CompilerBase compiler)
+        {
+            Consume(TokenType.IDENTIFIER, "Must provide name after a register statement.");
+            var stringConst = compiler.AddStringConstant();
+            Expression();
+            EmitOpAndBytes(OpCode.REGISTER, stringConst);
+            Consume(TokenType.END_STATEMENT, "Expect ';' after resgister.");
         }
 
         private void TCName(bool obj)
@@ -83,6 +100,12 @@
             CurrentChunk.AddConstantAndWriteInstruction(Value.New(cname), PreviousToken.Line);
         }
 
+        protected void Inject(bool canAssign)
+        {
+            Consume(TokenType.IDENTIFIER, "Expect property name after 'inject'.");
+            byte name = AddStringConstant();
+            EmitOpAndBytes(OpCode.INJECT, name);
+        }
         #endregion Expressions
     }
 }

--- a/Assets/ulox/Runtime/DataTypes/OpCode.cs
+++ b/Assets/ulox/Runtime/DataTypes/OpCode.cs
@@ -59,5 +59,8 @@
         TEST,
 
         BUILD,
+        
+        REGISTER,
+        INJECT,
     }
 }

--- a/Assets/ulox/Runtime/DataTypes/TokenType.cs
+++ b/Assets/ulox/Runtime/DataTypes/TokenType.cs
@@ -2,6 +2,10 @@
 {
     public enum TokenType
     {
+        EOF,
+
+        NONE,
+        
         OPEN_PAREN,
         CLOSE_PAREN,
         OPEN_BRACE,
@@ -9,10 +13,7 @@
         COMMA,
         DOT,
         END_STATEMENT,
-
-        //INCREMENT,
-        //DECREMENT,
-
+     
         MINUS,
         PLUS,
         SLASH,
@@ -79,10 +80,9 @@
         CONTEXT_NAME_TESTCASE,
         CONTEXT_NAME_TESTSET,
 
-        EOF,
-
-        NONE,
-
         BUILD,
+        
+        REGISTER,
+        INJECT,
     }
 }

--- a/Assets/ulox/Runtime/Engine/Disassembler.cs
+++ b/Assets/ulox/Runtime/Engine/Disassembler.cs
@@ -15,11 +15,12 @@
             opCodeHandlers[(int)OpCode.SUPER_INVOKE] = AppendStringConstantThenByte;
             opCodeHandlers[(int)OpCode.INVOKE] = AppendStringConstantThenByte;
 
-
-
             opCodeHandlers[(int)OpCode.TEST] = HandleTestOpCode;
 
             opCodeHandlers[(int)OpCode.BUILD] = AppendByteThenSpaceThenStringConstant;
+
+            opCodeHandlers[(int)OpCode.REGISTER] = AppendStringConstant;
+            opCodeHandlers[(int)OpCode.INJECT] = AppendStringConstant;
         }
 
         private int HandleTestOpCode(Chunk chunk, int i)

--- a/Assets/ulox/Runtime/Engine/VM.cs
+++ b/Assets/ulox/Runtime/Engine/VM.cs
@@ -15,6 +15,7 @@ namespace ULox
             if (otherVMbase is Vm otherVm)
             {
                 TestRunner = otherVm.TestRunner;
+                DiContainer = otherVm.DiContainer.ShallowCopy();
             }
         }
 

--- a/Assets/ulox/Runtime/Engine/VM.cs
+++ b/Assets/ulox/Runtime/Engine/VM.cs
@@ -6,7 +6,6 @@ namespace ULox
     {
         public TestRunner TestRunner { get; protected set; } = new TestRunner(() => new Vm());
         public DiContainer DiContainer { get; private set; } = new DiContainer();
-        private DiContainer _diContainerToRestore;
 
         public override void CopyFrom(VMBase otherVMbase)
         {
@@ -133,7 +132,7 @@ namespace ULox
                     var constantIndex = ReadByte(chunk);
                     var name = chunk.ReadConstant(constantIndex).val.asString;
                     var implementation = Pop();
-                    DiContainer[name] = implementation;
+                    DiContainer.Set(name,implementation);
                 }
                 break;
 

--- a/Assets/ulox/Runtime/Engine/VM.cs
+++ b/Assets/ulox/Runtime/Engine/VM.cs
@@ -2,11 +2,24 @@
 
 namespace ULox
 {
-    public class DependencyInjectionContainer : Table { }
+    public class DependencyInjectionContainer : Table
+    {
+        internal DependencyInjectionContainer ShallowCopy()
+        {
+            var ret = new DependencyInjectionContainer();
+            foreach (var pair in this)
+            {
+                ret.Add(pair.Key, pair.Value);
+            }
+            return ret;
+        }
+    }
+
     public class Vm : VMBase
     {
         public TestRunner TestRunner { get; protected set; } = new TestRunner(() => new Vm());
         public DependencyInjectionContainer DiContainer { get; private set; } = new DependencyInjectionContainer();
+        private DependencyInjectionContainer _diContainerToRestore;
 
         public override void CopyFrom(VMBase otherVMbase)
         {

--- a/Assets/ulox/Runtime/Engine/VM.cs
+++ b/Assets/ulox/Runtime/Engine/VM.cs
@@ -2,24 +2,11 @@
 
 namespace ULox
 {
-    public class DependencyInjectionContainer : Table
-    {
-        internal DependencyInjectionContainer ShallowCopy()
-        {
-            var ret = new DependencyInjectionContainer();
-            foreach (var pair in this)
-            {
-                ret.Add(pair.Key, pair.Value);
-            }
-            return ret;
-        }
-    }
-
     public class Vm : VMBase
     {
         public TestRunner TestRunner { get; protected set; } = new TestRunner(() => new Vm());
-        public DependencyInjectionContainer DiContainer { get; private set; } = new DependencyInjectionContainer();
-        private DependencyInjectionContainer _diContainerToRestore;
+        public DiContainer DiContainer { get; private set; } = new DiContainer();
+        private DiContainer _diContainerToRestore;
 
         public override void CopyFrom(VMBase otherVMbase)
         {

--- a/Assets/ulox/Runtime/Library/DiLibrary.cs
+++ b/Assets/ulox/Runtime/Library/DiLibrary.cs
@@ -1,0 +1,36 @@
+﻿namespace ULox
+{
+    public class DiLibrary : IULoxLibrary
+    {
+        private DiContainer _diCont;
+
+        public DiLibrary(DiContainer cont)
+        {
+            _diCont = cont;
+        }
+
+        public string Name => nameof(DiLibrary);
+
+        public Table GetBindings()
+        {
+            var resTable = new Table();
+            var assertInst = new InstanceInternal();
+            resTable.Add("DI", Value.New(assertInst));
+
+            assertInst.fields[nameof(Count)] = Value.New(Count);
+            assertInst.fields[nameof(GenerateDump)] = Value.New(GenerateDump);
+
+            return resTable;
+        }
+
+        private Value Count(VMBase vm, int argCount)
+        {
+            return Value.New(_diCont.Count);
+        }
+
+        private Value GenerateDump(VMBase vm, int argCount)
+        {
+            return Value.New(_diCont.GenerateDump());
+        }
+    }
+}

--- a/Assets/ulox/Runtime/Library/DiLibrary.cs
+++ b/Assets/ulox/Runtime/Library/DiLibrary.cs
@@ -2,13 +2,6 @@
 {
     public class DiLibrary : IULoxLibrary
     {
-        private DiContainer _diCont;
-
-        public DiLibrary(DiContainer cont)
-        {
-            _diCont = cont;
-        }
-
         public string Name => nameof(DiLibrary);
 
         public Table GetBindings()
@@ -19,18 +12,37 @@
 
             assertInst.fields[nameof(Count)] = Value.New(Count);
             assertInst.fields[nameof(GenerateDump)] = Value.New(GenerateDump);
+            assertInst.fields[nameof(Freeze)] = Value.New(Freeze);
 
             return resTable;
         }
 
         private Value Count(VMBase vm, int argCount)
         {
-            return Value.New(_diCont.Count);
+            var di = FromVm(vm);
+            return Value.New(di.Count);
         }
 
         private Value GenerateDump(VMBase vm, int argCount)
         {
-            return Value.New(_diCont.GenerateDump());
+            var di = FromVm(vm);
+            return Value.New(di.GenerateDump());
+        }
+
+        private Value Freeze(VMBase vm, int argCount)
+        {
+            var di = FromVm(vm);
+            di.Freeze();
+            return Value.Null();
+        }
+
+        private DiContainer FromVm(VMBase vMBase)
+        {
+            if(vMBase is Vm vm)
+            {
+                return vm.DiContainer;
+            }
+            throw new LoxException($"DiLibrary action taken on incommpatible vm.");
         }
     }
 }

--- a/Assets/ulox/Runtime/Library/DiLibrary.cs.meta
+++ b/Assets/ulox/Runtime/Library/DiLibrary.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 938de65ffe76e1a4d9b71309124b55a3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ulox/Runtime/Scanner/Scanner.cs
+++ b/Assets/ulox/Runtime/Scanner/Scanner.cs
@@ -22,7 +22,10 @@
                 ("super", TokenType.SUPER),
                 ("static", TokenType.STATIC),
                 ("init", TokenType.INIT),
-                ("cname", TokenType.CONTEXT_NAME_CLASS)
+                ("cname", TokenType.CONTEXT_NAME_CLASS),
+
+                ("inject", TokenType.INJECT),
+                ("register", TokenType.REGISTER)
                 );
 
             this.AddSingleCharTokenGenerators(

--- a/Assets/ulox/Runtime/VM.meta
+++ b/Assets/ulox/Runtime/VM.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4b102408dd814d140a5ddb4a990e2b71
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ulox/Runtime/VM/DiContainer.cs
+++ b/Assets/ulox/Runtime/VM/DiContainer.cs
@@ -1,0 +1,39 @@
+﻿using System.Text;
+
+namespace ULox
+{
+    public class DiContainer : Table
+    {
+        internal DiContainer ShallowCopy()
+        {
+            var ret = new DiContainer();
+            foreach (var pair in this)
+            {
+                ret.Add(pair.Key, pair.Value);
+            }
+            return ret;
+        }
+
+        internal void ReplaceWith(DiContainer diContainerToRestore)
+        {
+            Clear(); 
+            foreach (var pair in diContainerToRestore)
+            {
+                Add(pair.Key, pair.Value);
+            }
+        }
+
+        internal string GenerateDump()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("Registered in DI:");
+
+            foreach (var item in this)
+            {
+                sb.AppendLine($"{item.Key}:{item.Value}");
+            }
+
+            return sb.ToString().Trim();
+        }
+    }
+}

--- a/Assets/ulox/Runtime/VM/DiContainer.cs
+++ b/Assets/ulox/Runtime/VM/DiContainer.cs
@@ -2,38 +2,56 @@
 
 namespace ULox
 {
-    public class DiContainer : Table
+    public class DiContainer
     {
+        private bool _isFrozen = false;
+        private Table _diTable = new Table();
+
+        public int Count => _diTable.Count;
+
+        public void Freeze() => _isFrozen = true;
+
         internal DiContainer ShallowCopy()
         {
             var ret = new DiContainer();
-            foreach (var pair in this)
+            foreach (var pair in _diTable)
             {
-                ret.Add(pair.Key, pair.Value);
+                ret._diTable.Add(pair.Key, pair.Value);
             }
+
+            if (_isFrozen)
+                ret.Freeze();
+            
             return ret;
         }
 
         internal void ReplaceWith(DiContainer diContainerToRestore)
         {
-            Clear(); 
-            foreach (var pair in diContainerToRestore)
+            if (_isFrozen) return;
+            _diTable.Clear(); 
+            foreach (var pair in diContainerToRestore._diTable)
             {
-                Add(pair.Key, pair.Value);
+                _diTable.Add(pair.Key, pair.Value);
             }
         }
 
         internal string GenerateDump()
         {
             var sb = new StringBuilder();
-            sb.AppendLine("Registered in DI:");
+            sb.AppendLine($"Registered in DI{(_isFrozen?"(frozen)":"")}:");
 
-            foreach (var item in this)
+            foreach (var item in _diTable)
             {
                 sb.AppendLine($"{item.Key}:{item.Value}");
             }
 
             return sb.ToString().Trim();
         }
+
+        internal void Set(string name, Value implementation)
+            => _diTable[name] = implementation;
+
+        internal bool TryGetValue(string name, out Value found)
+            => _diTable.TryGetValue(name, out found);
     }
 }

--- a/Assets/ulox/Runtime/VM/DiContainer.cs.meta
+++ b/Assets/ulox/Runtime/VM/DiContainer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48e5eda2c963293468ef7512eb2d1304
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ulox/Tests/ByteCodeLoxEngineTests.cs
+++ b/Assets/ulox/Tests/ByteCodeLoxEngineTests.cs
@@ -94,6 +94,25 @@ print (a);");
         }
 
         [Test]
+        public void Engine_Cycle_UselessDeclare()
+        {
+            testEngine.Run(@"
+var a = 7;");
+
+            Assert.AreEqual("", testEngine.InterpreterResult);
+        }
+
+        [Test]
+        public void Engine_Cycle_UselessExpression()
+        {
+            testEngine.Run(@"
+var a = 7;
+a;");
+
+            Assert.AreEqual("", testEngine.InterpreterResult);
+        }
+
+        [Test]
         public void Engine_Cycle_Print_Math_Expression()
         {
             
@@ -2497,6 +2516,37 @@ print(cinst.b);
             Assert.AreEqual("112", testEngine.InterpreterResult);
         }
 
+        [Test]
+        public void Engine_Register_Unused()
+        {
+            testEngine.Run(@"
+register Seven 7;");
+
+            Assert.AreEqual("", testEngine.InterpreterResult);
+        }
+
+        [Test]
+        public void Engine_Inject_Error()
+        {
+            testEngine.Run(@"
+var s = inject Seven;");
+
+            Assert.AreEqual("Inject failure. Nothing has been registered (yet) with name 'Seven'.", testEngine.InterpreterResult);
+        }
+
+        [Test]
+        public void Engine_RegisterAndInject()
+        {
+            testEngine.Run(@"
+register Seven 7;
+var s = inject Seven;
+print(s);");
+
+            Assert.AreEqual("7", testEngine.InterpreterResult);
+        }
+
+        //todo yield should be able to multi return, use a yield stack in the vm and clear it at each use?
+        
         [Test]
         public void Engine_Class_Inher2ClassSuperInitParams()
         {

--- a/Assets/ulox/Tests/UloxScriptTests.cs
+++ b/Assets/ulox/Tests/UloxScriptTests.cs
@@ -31,7 +31,7 @@ public class UloxScriptTests
         engine.Engine.Context.DeclareLibrary(new DebugLibrary());
         engine.Engine.Context.DeclareLibrary(new StandardClassesLibrary());
         engine.Engine.Context.DeclareLibrary(new VmLibrary(() => new Vm()));
-        engine.Engine.Context.DeclareLibrary(new DiLibrary(engine.Vm.DiContainer));
+        engine.Engine.Context.DeclareLibrary(new DiLibrary());
     }
 
     [Test]

--- a/Assets/ulox/Tests/UloxScriptTests.cs
+++ b/Assets/ulox/Tests/UloxScriptTests.cs
@@ -31,6 +31,7 @@ public class UloxScriptTests
         engine.Engine.Context.DeclareLibrary(new DebugLibrary());
         engine.Engine.Context.DeclareLibrary(new StandardClassesLibrary());
         engine.Engine.Context.DeclareLibrary(new VmLibrary(() => new Vm()));
+        engine.Engine.Context.DeclareLibrary(new DiLibrary(engine.Vm.DiContainer));
     }
 
     [Test]

--- a/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Classes.ulox
+++ b/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Classes.ulox
@@ -1,0 +1,25 @@
+class ConcreteService 
+{
+    Meth(){return 1;}
+}
+
+class Dependent
+{
+    var service = inject Service;
+    Get{return this.service.Meth();}
+}
+
+test DISClassesTests
+{
+    testcase RegisterAndInject
+    {
+        register Service ConcreteService();
+        var expected = 1;
+        var result = 0;
+
+        var dep = Dependent();
+        result = dep.Get();
+
+        Assert.AreEqual(expected, result);        
+    }
+}

--- a/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Classes.ulox.meta
+++ b/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Classes.ulox.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 8c07fbf8325c0924da599a3b92e27308
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 510016c84ce283043a1ccba407656da6, type: 3}

--- a/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Library.ulox
+++ b/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Library.ulox
@@ -71,4 +71,19 @@ test DISimpleTests
 
         Assert.AreEqual(expected, result);
     }
+    
+
+    testcase ReRegisterAndInjectInSingleScope
+    {
+        var serviceInst = 7;
+        register Service serviceInst;
+        DI.Freeze();
+        register Service serviceInst;
+        var expected = serviceInst;
+        var result = 0;
+
+        result = inject Service;
+
+        Assert.AreEqual(expected, result);        
+    }
 }

--- a/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Library.ulox
+++ b/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Library.ulox
@@ -1,0 +1,46 @@
+build bind "DiLibrary";
+
+register DummyService null;
+
+test DISimpleTests
+{
+    testcase ValidateDiLibraryCount
+    {
+        var serviceInst = 7;
+        register Service1 serviceInst;
+        register Service2 null;
+        fun ServiceFunction(){}
+        register Service3 ServiceFunction;
+        var expected = 4;
+        var result = 0;
+
+        result = DI.Count();
+
+        Assert.AreEqual(expected,result);        
+    }
+
+    testcase ValidateDiLibraryCountDummyOnly
+    {
+        var expected = 1;
+        var result = 0;
+
+        result = DI.Count();
+
+        Assert.AreEqual(expected,result);        
+    }
+
+    testcase ValidateDiLibraryDump
+    {
+        var serviceInst = 7;
+        register Service1 serviceInst;
+        register Service2 null;
+        fun ServiceFunction(a){return a;}
+        var result = "";
+
+        result = DI.GenerateDump();
+
+        Assert.DoesContain("DummyService:null",result);
+        Assert.DoesContain("Service1:7",result);
+        Assert.DoesContain("Service2:null",result);
+    }
+}

--- a/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Library.ulox
+++ b/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Library.ulox
@@ -1,6 +1,17 @@
-build bind "DiLibrary";
+build bind 
+    "DiLibrary",
+    "VmLibrary";
 
 register DummyService null;
+
+fun InnerMainInjectedScale()
+{
+    var scale = inject ParentService;
+    a *= scale;
+}
+
+var a = 0;
+
 
 test DISimpleTests
 {
@@ -42,5 +53,22 @@ test DISimpleTests
         Assert.DoesContain("DummyService:null",result);
         Assert.DoesContain("Service1:7",result);
         Assert.DoesContain("Service2:null",result);
+    }
+    
+    testcase InherDiFromParentVM
+    {
+        var expected = 20;
+        var startingValue = 10;
+        var result = 0;
+        var innerVM = VM();
+        register ParentService 2;
+
+        a = startingValue;
+        innerVM.InheritFromEnclosing();
+        innerVM.Start(InnerMainInjectedScale);
+        innerVM.CopyBackToEnclosing();
+        result = a;
+
+        Assert.AreEqual(expected, result);
     }
 }

--- a/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Library.ulox.meta
+++ b/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Library.ulox.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 500d397e399788f439ac84f5eea7e1d7
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 510016c84ce283043a1ccba407656da6, type: 3}

--- a/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Simple.ulox
+++ b/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Simple.ulox
@@ -1,6 +1,6 @@
 test DISimpleTests
 {
-    testcase RegisterAndInject
+    testcase RegisterAndInjectInSingleScope
     {
         //[statement] register <constant string> <expression>
         var serviceInst = 7;
@@ -13,10 +13,16 @@ test DISimpleTests
 
         Assert.AreEqual(expected, result);        
     }
-    /*
-    class InjectedThing
+
+    testcase ReRegisterAndInjectInSingleScope
     {
-        var a = inject Service;
+        var serviceInst = 7;
+        register Service serviceInst;
+        register Service null;
+        var result = 0;
+
+        result = inject Service;
+
+        Assert.IsNull(result);        
     }
-    */
 }

--- a/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Simple.ulox
+++ b/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Simple.ulox
@@ -25,4 +25,17 @@ test DISimpleTests
 
         Assert.IsNull(result);        
     }
+
+    testcase RegisterAndInjectIntoFunc
+    {
+        var serviceInst = 7;
+        register Service serviceInst;
+        var expected = 8;
+        var result = 0;
+        fun InjectedIsReturnedPlus1(a){return a+1;}
+
+        result = InjectedIsReturnedPlus1(inject Service);
+
+        Assert.AreEqual(expected, result);        
+    }
 }

--- a/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Simple.ulox
+++ b/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Simple.ulox
@@ -1,0 +1,22 @@
+test DISimpleTests
+{
+    testcase RegisterAndInject
+    {
+        //[statement] register <constant string> <expression>
+        var serviceInst = 7;
+        register Service serviceInst;
+        var expected = 7;
+        var result = 0;
+
+        //[expression]<assign statement> = inject <constant string>(resolves to a lookup and push stack)
+        result = inject Service;
+
+        Assert.AreEqual(expected, result);        
+    }
+    /*
+    class InjectedThing
+    {
+        var a = inject Service;
+    }
+    */
+}

--- a/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Simple.ulox.meta
+++ b/Assets/ulox/Tests/uLoxTestScripts/NoFail/DI-Simple.ulox.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 56317d17a6bc89847a31095a97089d74
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 510016c84ce283043a1ccba407656da6, type: 3}

--- a/Assets/ulox/Tests/uLoxTestScripts/NoFail/VMLibrary.ulox
+++ b/Assets/ulox/Tests/uLoxTestScripts/NoFail/VMLibrary.ulox
@@ -1,4 +1,6 @@
-build bind "VmLibrary";
+build bind 
+    "VmLibrary",
+    "VmLibrary";
 
 test VMLibraryTests
 {


### PR DESCRIPTION
Represents in progress proposal for DI in ulox.

closes #4 

- [x] Register an object by an identifier for later injection
- [x] inject a registered object into a field by matching identifier
- [x] inject resolves to object reference in function params
- [x] inject resolves to object reference in class var decls
- [x] DI Container persists throughout the run
- [x] DI container is restores itself to previous state after a testcase
- [x] DI container can be accessed by child vm
- [x] DI library providing access to count and GenerateDump
- [x] ability to freeze the DI