### PR TITLE
Change BuildOp Compiler and VM

### DIFF
--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/BuildCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/BuildCompilette.cs
@@ -31,10 +31,8 @@
             //read the rest of the constants and write out build opcodes
             do
             {
-                compiler.TokenIterator.Consume(TokenType.STRING, "Expect string after build op type.");
-                var ident = (string)compiler.TokenIterator.PreviousToken.Literal;
-                var identId = compiler.CurrentChunk.AddConstant(Value.New(ident));
-                compiler.EmitOpAndBytes(OpCode.BUILD, (byte)buildOpType, identId);
+                compiler.Expression();
+                compiler.EmitOpAndBytes(OpCode.BUILD, (byte)buildOpType);
             } while (compiler.TokenIterator.Match(TokenType.COMMA));
 
             compiler.ConsumeEndStatement("build command identifier(s)");

--- a/ulox/ulox.core/Package/Runtime/Engine/Disassembler.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/Disassembler.cs
@@ -68,7 +68,7 @@ namespace ULox
 
             opCodeHandlers[(int)OpCode.TEST] = HandleTestOpCode;
 
-            opCodeHandlers[(int)OpCode.BUILD] = AppendByteThenSpaceThenStringConstant;
+            opCodeHandlers[(int)OpCode.BUILD] = AppendByte;
 
             opCodeHandlers[(int)OpCode.REGISTER] = AppendStringConstant;
             opCodeHandlers[(int)OpCode.INJECT] = AppendStringConstant;
@@ -310,13 +310,6 @@ namespace ULox
             i = AppendStringConstant(chunk, i);
             AppendSpace();
             return AppendUShort(chunk, i);
-        }
-
-        private int AppendByteThenSpaceThenStringConstant(Chunk chunk, int i)
-        {
-            i = AppendByte(chunk, i);
-            AppendSpace();
-            return AppendStringConstant(chunk, i);
         }
 
         private int AppendStringConstantThenByte(Chunk chunk, int i)

--- a/ulox/ulox.core/Package/Runtime/Engine/VM.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/VM.cs
@@ -551,17 +551,17 @@ namespace ULox
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void DoBuildOp(Chunk chunk)
         {
+            var givenVar = Pop();
+            var str = givenVar.str();
             var buildOpType = (BuildOpType)ReadByte(chunk);
-            var constantIndex = ReadByte(chunk);
-            var str = chunk.ReadConstant(constantIndex).val.asString;
             switch (buildOpType)
             {
             case BuildOpType.Bind:
-                Engine.Context.BindLibrary(str.String);
+                Engine.Context.BindLibrary(str);
                 break;
 
             case BuildOpType.Queue:
-                Engine.LocateAndQueue(str.String);
+                Engine.LocateAndQueue(str);
                 break;
 
             default:


### PR DESCRIPTION
Now expects an expression value on stack ahead of it rather than known constant index.
Simpler and less special cases in disassm

closes #72 