### PR TITLE
Goto labels

### DIFF
--- a/ulox/ulox.core.tests/ContractTests.cs
+++ b/ulox/ulox.core.tests/ContractTests.cs
@@ -89,7 +89,7 @@ class T
     signs IT;
 }");
 
-            StringAssert.StartsWith("Sign failure with msg ''T' does not contain matching method 'Required'.' at ip:'38' in chunk:'unnamed_chunk(test:10)'.", testEngine.InterpreterResult);
+            StringAssert.StartsWith("Sign failure with msg ''T' does not contain matching method 'Required'.' at ip:", testEngine.InterpreterResult);
         }
 
         [Test]
@@ -107,7 +107,7 @@ class T
     Required(a){}
 }");
 
-            StringAssert.StartsWith("Sign failure with msg 'Expected arity '0' but found '1'.' at ip:'42' in chunk:'unnamed_chunk(test:11)'.", testEngine.InterpreterResult);
+            StringAssert.StartsWith("Sign failure with msg 'Expected arity '0' but found '1'.' at ip:", testEngine.InterpreterResult);
         }
 
         [Test]
@@ -148,7 +148,7 @@ class T
     Required(){}
 }");
 
-            StringAssert.StartsWith("Sign failure with msg 'Expected local but found 'Method'.' at ip:'42' in chunk:'unnamed_chunk(test:11)'.", testEngine.InterpreterResult);
+            StringAssert.StartsWith("Sign failure with msg 'Expected local but found 'Method'.' at ip:", testEngine.InterpreterResult);
         }
 
         [Test]
@@ -202,7 +202,7 @@ class T
     Required(){}
 }");
 
-            StringAssert.StartsWith("Sign failure with msg 'Expected pure but found 'Method'.' at ip:'42' in chunk:'unnamed_chunk(test:11)'.", testEngine.InterpreterResult);
+            StringAssert.StartsWith("Sign failure with msg 'Expected pure but found 'Method'.' at ip:", testEngine.InterpreterResult);
         }
 
         [Test]

--- a/ulox/ulox.core.tests/LabelTests.cs
+++ b/ulox/ulox.core.tests/LabelTests.cs
@@ -1,0 +1,19 @@
+﻿using NUnit.Framework;
+
+namespace ulox.core.tests
+{
+    public class LabelTests : EngineTestBase
+    {
+        [Test]
+        public void Engine_MapEmtpy_Count0()
+        {
+            testEngine.Run(@"
+goto end;
+print(fail);
+label end;
+");
+
+            Assert.AreEqual("", testEngine.InterpreterResult);
+        }
+    }
+}

--- a/ulox/ulox.core.tests/LoopingTests.cs
+++ b/ulox/ulox.core.tests/LoopingTests.cs
@@ -327,7 +327,7 @@ loop (arr)
 }
 ");
 
-            StringAssert.StartsWith("Cannot perform countof on '7' at ip:'22' in chunk:'unnamed_chunk(test:4)'.", testEngine.InterpreterResult);
+            StringAssert.StartsWith("Cannot perform countof on '7' at ip:", testEngine.InterpreterResult);
         }
 
         [Test]
@@ -341,7 +341,7 @@ loop (arr)
 }
 ");
 
-            StringAssert.StartsWith("Cannot perform countof on 'str' at ip:'22' in chunk:'unnamed_chunk(test:4)'.", testEngine.InterpreterResult);
+            StringAssert.StartsWith("Cannot perform countof on 'str' at ip:", testEngine.InterpreterResult);
         }
 
         [Test]

--- a/ulox/ulox.core.tests/LoopingTests.cs
+++ b/ulox/ulox.core.tests/LoopingTests.cs
@@ -407,7 +407,7 @@ loop (arr)
 }
 ");
 
-            StringAssert.StartsWith("Cannot perform countof on '<inst Stub>' at ip:'39' in chunk:'unnamed_chunk(test:5)'.", testEngine.InterpreterResult);
+            StringAssert.StartsWith("Cannot perform countof on '<inst Stub>' at ip:", testEngine.InterpreterResult);
         }
 
         [Test]
@@ -437,7 +437,7 @@ loop (arr)
 }
 ");
 
-            StringAssert.StartsWith("1Cannot perform get index on type 'Instance' at ip:'75' in chunk:'unnamed_chunk(test:7)'.", testEngine.InterpreterResult);
+            StringAssert.StartsWith("1Cannot perform get index on type 'Instance' at ip:", testEngine.InterpreterResult);
         }
 
         [Test]

--- a/ulox/ulox.core.tests/uloxs/Tests/ControlFlow.ulox
+++ b/ulox/ulox.core.tests/uloxs/Tests/ControlFlow.ulox
@@ -119,21 +119,6 @@ test ControlFlow
         Assert.AreEqual(expected, accum);
     }
 
-    testcase ForNoInc
-    {
-        var expected = 4951;
-        var limit = 100;
-        var accum = 1;
-
-        for(var i = 0; i < limit;)
-        {
-            accum += i;
-            i += 1;
-        }
-
-        Assert.AreEqual(expected, accum);
-    }
-
     testcase Break
     {
         var expected = 1024;
@@ -214,27 +199,6 @@ test ControlFlow
         var i = 0;
 
         loop
-        {
-            i += 1;
-
-            if(i >= limit) break;
-
-            if(i % 2 == 0) continue;
-
-            accum += 1;
-        }
-
-        Assert.AreEqual(expected, accum);
-    }
-
-    testcase ContinueEmptyFor
-    {
-        var expected = 51;
-        var limit = 100;
-        var accum = 1;
-        var i = 0;
-
-        for(;;)
         {
             i += 1;
 

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compiler.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compiler.cs
@@ -494,17 +494,6 @@ namespace ULox
         public byte ArgumentList()
             => ExpressionList(TokenType.CLOSE_PAREN, "Expect ')' after arguments.");
 
-        public void EmitLoop(int loopStart)
-        {
-            EmitOpCode(OpCode.LOOP);
-            int offset = CurrentChunk.Instructions.Count - loopStart + 2;
-
-            if (offset > ushort.MaxValue)
-                ThrowCompilerException($"Cannot loop '{offset}'. Max loop is '{ushort.MaxValue}'");
-
-            EmitBytes((byte)((offset >> 8) & 0xff), (byte)(offset & 0xff));
-        }
-
         public byte ParseVariable(string errMsg)
         {
             TokenIterator.Consume(TokenType.IDENTIFIER, errMsg);
@@ -838,7 +827,7 @@ namespace ULox
             if (comp.LoopStates.Count == 0)
                 compiler.ThrowCompilerException($"Cannot continue when not inside a loop.");
 
-            compiler.EmitLoop(comp.LoopStates.Peek().loopContinuePoint);
+            compiler.EmitGoto(comp.LoopStates.Peek().ContinueLabelID);
 
             compiler.ConsumeEndStatement();
         }

--- a/ulox/ulox.core/Package/Runtime/Compiler/CompilerState.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/CompilerState.cs
@@ -20,7 +20,6 @@ namespace ULox
         public class LoopState
         {
             public int loopContinuePoint = -1;
-            public int loopStartPoint = -1;
             public List<int> loopExitPatchLocations = new List<int>();
             public byte ExitLabelID;
             public byte ContinueLabelID;

--- a/ulox/ulox.core/Package/Runtime/Compiler/CompilerState.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/CompilerState.cs
@@ -19,7 +19,6 @@ namespace ULox
 
         public class LoopState
         {
-            public int loopContinuePoint = -1;
             public List<int> loopExitPatchLocations = new List<int>();
             public byte ExitLabelID;
             public byte ContinueLabelID;

--- a/ulox/ulox.core/Package/Runtime/Compiler/CompilerState.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/CompilerState.cs
@@ -20,13 +20,16 @@ namespace ULox
         public class LoopState
         {
             public int loopContinuePoint = -1;
+            public int loopStartPoint = -1;
             public List<int> loopExitPatchLocations = new List<int>();
-            public byte loopExitLabelID;
+            public byte ExitLabelID;
+            public byte ContinueLabelID;
+            public byte StartLabelID;
             public bool HasExit = false;
 
-            public LoopState(byte loopExitLabelID)
+            public LoopState(byte exitLabelID)
             {
-                this.loopExitLabelID = loopExitLabelID;
+                ExitLabelID = exitLabelID;
             }
         }
 

--- a/ulox/ulox.core/Package/Runtime/Compiler/CompilerState.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/CompilerState.cs
@@ -21,6 +21,13 @@ namespace ULox
         {
             public int loopContinuePoint = -1;
             public List<int> loopExitPatchLocations = new List<int>();
+            public byte loopExitLabelID;
+            public bool HasExit = false;
+
+            public LoopState(byte loopExitLabelID)
+            {
+                this.loopExitLabelID = loopExitLabelID;
+            }
         }
 
         internal class Upvalue

--- a/ulox/ulox.core/Package/Runtime/Compiler/CompilerState.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/CompilerState.cs
@@ -19,7 +19,6 @@ namespace ULox
 
         public class LoopState
         {
-            public List<int> loopExitPatchLocations = new List<int>();
             public byte ExitLabelID;
             public byte ContinueLabelID;
             public byte StartLabelID;

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ConfigurableLoopingStatementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ConfigurableLoopingStatementCompilette.cs
@@ -26,9 +26,8 @@ namespace ULox
 
             PreLoop(compiler, loopState);
             
-            var loopStart = compiler.CurrentChunkInstructinCount;
             loopState.StartLabelID = compiler.LabelUniqueChunkLabel("loop_start");
-            loopState.loopContinuePoint = loopStart;
+            loopState.ContinueLabelID = loopState.StartLabelID;
 
             BeginLoop(compiler, loopState);
 

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ConfigurableLoopingStatementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ConfigurableLoopingStatementCompilette.cs
@@ -35,8 +35,9 @@ namespace ULox
 
             compiler.EmitGoto(loopState.StartLabelID);
 
-            PatchLoopExits(compiler, loopState);
-
+            if (!loopState.HasExit)
+                compiler.ThrowCompilerException("Loops must contain a termination");
+            compiler.EmitLabel(loopState.ExitLabelID);
             compiler.EmitOpCode(OpCode.POP);
 
             compiler.EndScope();
@@ -45,19 +46,5 @@ namespace ULox
         protected abstract void PreLoop(Compiler compiler, LoopState loopState);
 
         protected abstract void BeginLoop(Compiler compiler, LoopState loopState);
-
-        protected void PatchLoopExits(Compiler compiler, LoopState loopState)
-        {
-            if (loopState.loopExitPatchLocations.Count == 0
-                && !loopState.HasExit)
-                compiler.ThrowCompilerException("Loops must contain a termination");
-
-            for (int i = 0; i < loopState.loopExitPatchLocations.Count; i++)
-            {
-                compiler.PatchJump(loopState.loopExitPatchLocations[i]);
-            }
-
-            compiler.EmitLabel(loopState.ExitLabelID);
-        }
     }
 }

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ConfigurableLoopingStatementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ConfigurableLoopingStatementCompilette.cs
@@ -27,14 +27,14 @@ namespace ULox
             PreLoop(compiler, loopState);
             
             var loopStart = compiler.CurrentChunkInstructinCount;
-            loopState.loopStartPoint = loopStart;
+            loopState.StartLabelID = compiler.LabelUniqueChunkLabel("loop_start");
             loopState.loopContinuePoint = loopStart;
 
             BeginLoop(compiler, loopState);
 
             compiler.Statement();
 
-            compiler.EmitLoop(loopState.loopStartPoint);
+            compiler.EmitGoto(loopState.StartLabelID);
 
             PatchLoopExits(compiler, loopState);
 

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ConfigurableLoopingStatementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ConfigurableLoopingStatementCompilette.cs
@@ -22,7 +22,7 @@ namespace ULox
 
             var comp = compiler.CurrentCompilerState;
             int loopStart = compiler.CurrentChunkInstructinCount;
-            var loopState = new LoopState();
+            var loopState = new LoopState(compiler.UniqueChunkStringConstant("loop_exit"));
             comp.LoopStates.Push(loopState);
             loopState.loopContinuePoint = loopStart;
 
@@ -33,6 +33,7 @@ namespace ULox
             compiler.EmitLoop(loopStart);
 
             PatchLoopExits(compiler, loopState);
+            compiler.EmitLabel(loopState.loopExitLabelID);
 
             compiler.EmitOpCode(OpCode.POP);
 
@@ -43,7 +44,8 @@ namespace ULox
 
         protected void PatchLoopExits(Compiler compiler, LoopState loopState)
         {
-            if (loopState.loopExitPatchLocations.Count == 0)
+            if (loopState.loopExitPatchLocations.Count == 0
+                && !loopState.HasExit)
                 compiler.ThrowCompilerException("Loops must contain a termination");
 
             for (int i = 0; i < loopState.loopExitPatchLocations.Count; i++)

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ForStatementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ForStatementCompilette.cs
@@ -25,13 +25,14 @@ namespace ULox
             var bodyJump = compiler.GoToUniqueChunkLabel("loop_body");
             //increment
             {
+                var newStartLabel = compiler.LabelUniqueChunkLabel("loop_start");
                 int incrementStart = compiler.CurrentChunkInstructinCount;
                 loopState.loopContinuePoint = incrementStart;
                 compiler.Expression();
                 compiler.EmitOpCode(OpCode.POP);
 
-                compiler.EmitLoop(loopState.loopStartPoint);
-                loopState.loopStartPoint = incrementStart;
+                compiler.EmitGoto(loopState.StartLabelID);
+                loopState.StartLabelID = newStartLabel;
                 compiler.EmitLabel(bodyJump);
             }
             

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ForStatementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ForStatementCompilette.cs
@@ -26,8 +26,7 @@ namespace ULox
             //increment
             {
                 var newStartLabel = compiler.LabelUniqueChunkLabel("loop_start");
-                int incrementStart = compiler.CurrentChunkInstructinCount;
-                loopState.loopContinuePoint = incrementStart;
+                loopState.ContinueLabelID = newStartLabel;
                 compiler.Expression();
                 compiler.EmitOpCode(OpCode.POP);
 

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ForStatementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ForStatementCompilette.cs
@@ -17,12 +17,12 @@ namespace ULox
                 compiler.ConsumeEndStatement("loop condition");
 
                 // Jump out of the loop if the condition is false.
-                var exitJump = compiler.EmitJumpIf();
-                loopState.loopExitPatchLocations.Add(exitJump);
+                compiler.EmitGotoIf(loopState.ExitLabelID);
+                loopState.HasExit = true;
                 compiler.EmitOpCode(OpCode.POP); // Condition.
             }
 
-            var bodyJump = compiler.GoToUniqueChunkLabel("loop_body");
+            var bodyJump = compiler.GotoUniqueChunkLabel("loop_body");
             //increment
             {
                 var newStartLabel = compiler.LabelUniqueChunkLabel("loop_start");

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ForStatementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ForStatementCompilette.cs
@@ -9,53 +9,38 @@ namespace ULox
         {
         }
 
-        protected override int BeginLoop(Compiler compiler, int loopStart, CompilerState.LoopState loopState)
+        protected override void BeginLoop(Compiler compiler, CompilerState.LoopState loopState)
         {
-            compiler.TokenIterator.Consume(TokenType.OPEN_PAREN, "Expect '(' after loop with conditions.");
-
-            ForLoopInitialisationStatement(compiler);
-
-            loopStart = compiler.CurrentChunkInstructinCount;
-            loopState.loopContinuePoint = loopStart;
-
-            if (!compiler.TokenIterator.Match(TokenType.END_STATEMENT))
+            //condition
             {
-                ForLoopCondtionStatement(compiler, loopState);
+                compiler.Expression();
+                compiler.ConsumeEndStatement("loop condition");
+
+                // Jump out of the loop if the condition is false.
+                var exitJump = compiler.EmitJumpIf();
+                loopState.loopExitPatchLocations.Add(exitJump);
+                compiler.EmitOpCode(OpCode.POP); // Condition.
             }
 
-            if (!compiler.TokenIterator.Check(TokenType.CLOSE_PAREN))
+            var bodyJump = compiler.GoToUniqueChunkLabel("loop_body");
+            //increment
             {
-                var bodyJump = compiler.GoToUniqueChunkLabel("loop_body");
-
                 int incrementStart = compiler.CurrentChunkInstructinCount;
                 loopState.loopContinuePoint = incrementStart;
                 compiler.Expression();
                 compiler.EmitOpCode(OpCode.POP);
 
-                //TODO: shouldn't you be able to omit the post loop action and have it work. this seems like it breaks it.
-                compiler.EmitLoop(loopStart);
-                loopStart = incrementStart;
+                compiler.EmitLoop(loopState.loopStartPoint);
+                loopState.loopStartPoint = incrementStart;
                 compiler.EmitLabel(bodyJump);
             }
-
+            
             compiler.TokenIterator.Consume(TokenType.CLOSE_PAREN, "Expect ')' after loop clauses.");
-
-            return loopStart;
         }
 
-        protected void ForLoopCondtionStatement(Compiler compiler, LoopState loopState)
+        protected override void PreLoop(Compiler compiler, LoopState loopState)
         {
-            compiler.Expression();
-            compiler.ConsumeEndStatement("loop condition");
-
-            // Jump out of the loop if the condition is false.
-            var exitJump = compiler.EmitJumpIf();
-            loopState.loopExitPatchLocations.Add(exitJump);
-            compiler.EmitOpCode(OpCode.POP); // Condition.
-        }
-
-        protected void ForLoopInitialisationStatement(Compiler compiler)
-        {
+            compiler.TokenIterator.Consume(TokenType.OPEN_PAREN, "Expect '(' after loop with conditions.");
             //we really only want a var decl, var assign, or empty but Declaration covers everything
             compiler.Declaration();
         }

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ForStatementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ForStatementCompilette.cs
@@ -25,7 +25,7 @@ namespace ULox
 
             if (!compiler.TokenIterator.Check(TokenType.CLOSE_PAREN))
             {
-                int bodyJump = compiler.EmitJump();
+                var bodyJump = compiler.GoToUniqueChunkLabel("loop_body");
 
                 int incrementStart = compiler.CurrentChunkInstructinCount;
                 loopState.loopContinuePoint = incrementStart;
@@ -35,7 +35,7 @@ namespace ULox
                 //TODO: shouldn't you be able to omit the post loop action and have it work. this seems like it breaks it.
                 compiler.EmitLoop(loopStart);
                 loopStart = incrementStart;
-                compiler.PatchJump(bodyJump);
+                compiler.EmitLabel(bodyJump);
             }
 
             compiler.TokenIterator.Consume(TokenType.CLOSE_PAREN, "Expect ')' after loop clauses.");

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/LoopStatementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/LoopStatementCompilette.cs
@@ -65,7 +65,7 @@
             compiler.EmitOpAndBytes(OpCode.SET_LOCAL, itemArgID);
 
             loopState.StartLabelID = compiler.LabelUniqueChunkLabel("loop_start");
-            loopState.loopContinuePoint = compiler.CurrentChunkInstructinCount;
+            loopState.ContinueLabelID = loopState.StartLabelID;
             {
                 //confirm that the index isn't over the length of the array
                 IsIndexLessThanArrayCount(compiler, arrayGetOp, arrayArgId, indexArgID);
@@ -79,8 +79,7 @@
             var bodyJump = compiler.GoToUniqueChunkLabel("inc_body");
             {
                 var newStartLabel = compiler.LabelUniqueChunkLabel("loop_start");
-                var incrementStart = compiler.CurrentChunkInstructinCount;
-                loopState.loopContinuePoint = incrementStart;
+                loopState.ContinueLabelID = newStartLabel;
                 IncrementLocalByOne(compiler, indexArgID);
                 compiler.EmitGoto(loopState.StartLabelID);
                 loopState.StartLabelID = newStartLabel;

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/LoopStatementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/LoopStatementCompilette.cs
@@ -2,105 +2,99 @@
 {
     public class LoopStatementCompilette : ConfigurableLoopingStatementCompilette
     {
-        public LoopStatementCompilette() 
+        public LoopStatementCompilette()
             : base(TokenType.LOOP)
         {
         }
 
-        protected override int BeginLoop(Compiler compiler, int loopStart, CompilerState.LoopState loopState)
+        protected override void BeginLoop(Compiler compiler, CompilerState.LoopState loopState)
         {
             //if we have a ( then it could be a native array loop, so expand for that
             //if not it's a manual exit loop
-            if (compiler.TokenIterator.Match(TokenType.OPEN_PAREN))
+            if (!compiler.TokenIterator.Match(TokenType.OPEN_PAREN))
+                return;
+            
+            //temp
+            compiler.TokenIterator.Consume(TokenType.IDENTIFIER, "Expect identifier after loop statement with arg.");
+            var arrayName = compiler.TokenIterator.PreviousToken.Lexeme;
+            var (arrayGetOp, _, arrayArgId) = compiler.ResolveNameLookupOpCode(arrayName);
+            var itemName = "item";
+            var indexName = "i";
+
+            if (compiler.TokenIterator.Match(TokenType.COMMA))
             {
-                //temp
-                compiler.TokenIterator.Consume(TokenType.IDENTIFIER, "Expect identifier after loop statement with arg.");
-                var arrayName = compiler.TokenIterator.PreviousToken.Lexeme;
-                var (arrayGetOp, _, arrayArgId) = compiler.ResolveNameLookupOpCode(arrayName);
-                var itemName = "item";
-                var indexName = "i";
-                
-                if(compiler.TokenIterator.Match(TokenType.COMMA))
-                {
-                    //that's the item name
-                    compiler.TokenIterator.Consume(TokenType.IDENTIFIER, "Expect identifier after first comma in loop statement with arg.");
-                    itemName = compiler.TokenIterator.PreviousToken.Lexeme;
-                }
-                
-                if (compiler.TokenIterator.Match(TokenType.COMMA))
-                {
-                    //that's the index name
-                    compiler.TokenIterator.Consume(TokenType.IDENTIFIER, "Expect identifier after first comma in loop statement with arg.");
-                    indexName = compiler.TokenIterator.PreviousToken.Lexeme;
-                }
-
-                if (compiler.CurrentCompilerState.ResolveLocal(compiler, itemName) != -1)
-                {
-                    var prevToken = compiler.TokenIterator.PreviousToken;
-                    compiler.ThrowCompilerException($"Loop error: itemName '{itemName}' already exists at this scope, name given to loop must be unique");
-                }
-                if (compiler.CurrentCompilerState.ResolveLocal(compiler, indexName) != -1)
-                {
-                    var prevToken = compiler.TokenIterator.PreviousToken;
-                    compiler.ThrowCompilerException($"Loop error: indexName '{indexName}' already exists at this scope, name used for index in loop must be unique");
-                }
-
-                //skip the looop if the target is null
-                compiler.EmitOpAndBytes(arrayGetOp, arrayArgId);
-                int exitJumpArrayIsNullLocation = compiler.EmitJumpIf();
-                loopState.loopExitPatchLocations.Add(exitJumpArrayIsNullLocation);
-                compiler.EmitOpCode(OpCode.POP);
-
-                //refer to output of For_WhenLimitedIterations_ShouldPrint3Times 
-                compiler.CurrentCompilerState.DeclareVariableByName(compiler, indexName);
-                compiler.CurrentCompilerState.MarkInitialised();
-                var indexArgID = (byte)compiler.CurrentCompilerState.ResolveLocal(compiler, indexName);
-                compiler.CurrentCompilerState.DeclareVariableByName(compiler, itemName);
-                compiler.CurrentCompilerState.MarkInitialised();
-                var itemArgID = (byte)compiler.CurrentCompilerState.ResolveLocal(compiler, itemName);
-                
-                //prep i
-                compiler.EmitOpAndBytes(OpCode.PUSH_BYTE, 0);
-                compiler.EmitOpAndBytes(OpCode.SET_LOCAL, indexArgID);
-                compiler.EmitNULL();
-                compiler.EmitOpAndBytes(OpCode.SET_LOCAL, itemArgID);
-
-                loopStart = compiler.CurrentChunkInstructinCount;
-                loopState.loopContinuePoint = loopStart;
-                {
-                    //confirm that the index isn't over the length of the array
-                    IsIndexLessThanArrayCount(compiler, arrayGetOp, arrayArgId, indexArgID);
-
-                    //run the condition 
-                    var exitJump = compiler.EmitJumpIf();
-                    loopState.loopExitPatchLocations.Add(exitJump);
-                    compiler.EmitOpCode(OpCode.POP); // Condition.
-                }
-                //increment
-                var bodyJump = compiler.GoToUniqueChunkLabel("inc_body");
-                {
-                    int incrementStart = compiler.CurrentChunkInstructinCount;
-                    loopState.loopContinuePoint = incrementStart;
-                    IncrementLocalByOne(compiler, indexArgID);
-                    compiler.EmitLoop(loopStart);
-                    loopStart = incrementStart;
-                    compiler.EmitLabel(bodyJump);
-                }
-                compiler.TokenIterator.Consume(TokenType.CLOSE_PAREN, "Expect ')' after loop clauses.");
-
-                //prep item infront of body
-                {
-                    compiler.EmitOpAndBytes(arrayGetOp, arrayArgId);
-                    compiler.EmitOpAndBytes(OpCode.GET_LOCAL, indexArgID);
-                    compiler.EmitOpCode(OpCode.GET_INDEX);
-                    compiler.EmitOpAndBytes(OpCode.SET_LOCAL, itemArgID);
-                    compiler.EmitOpCode(OpCode.POP);
-                }
-
-                return loopStart;
+                //that's the item name
+                compiler.TokenIterator.Consume(TokenType.IDENTIFIER, "Expect identifier after first comma in loop statement with arg.");
+                itemName = compiler.TokenIterator.PreviousToken.Lexeme;
             }
 
-            return loopStart;
+            if (compiler.TokenIterator.Match(TokenType.COMMA))
+            {
+                //that's the index name
+                compiler.TokenIterator.Consume(TokenType.IDENTIFIER, "Expect identifier after first comma in loop statement with arg.");
+                indexName = compiler.TokenIterator.PreviousToken.Lexeme;
+            }
+
+            if (compiler.CurrentCompilerState.ResolveLocal(compiler, itemName) != -1)
+            {
+                compiler.ThrowCompilerException($"Loop error: itemName '{itemName}' already exists at this scope, name given to loop must be unique");
+            }
+            if (compiler.CurrentCompilerState.ResolveLocal(compiler, indexName) != -1)
+            {
+                compiler.ThrowCompilerException($"Loop error: indexName '{indexName}' already exists at this scope, name used for index in loop must be unique");
+            }
+
+            //skip the loop if the target is null
+            compiler.EmitOpAndBytes(arrayGetOp, arrayArgId);
+            int exitJumpArrayIsNullLocation = compiler.EmitJumpIf();
+            loopState.loopExitPatchLocations.Add(exitJumpArrayIsNullLocation);
+            compiler.EmitOpCode(OpCode.POP);
+
+            //refer to output of For_WhenLimitedIterations_ShouldPrint3Times 
+            compiler.CurrentCompilerState.DeclareVariableByName(compiler, indexName);
+            compiler.CurrentCompilerState.MarkInitialised();
+            var indexArgID = (byte)compiler.CurrentCompilerState.ResolveLocal(compiler, indexName);
+            compiler.CurrentCompilerState.DeclareVariableByName(compiler, itemName);
+            compiler.CurrentCompilerState.MarkInitialised();
+            var itemArgID = (byte)compiler.CurrentCompilerState.ResolveLocal(compiler, itemName);
+
+            //prep i
+            compiler.EmitOpAndBytes(OpCode.PUSH_BYTE, 0);
+            compiler.EmitOpAndBytes(OpCode.SET_LOCAL, indexArgID);
+            compiler.EmitNULL();
+            compiler.EmitOpAndBytes(OpCode.SET_LOCAL, itemArgID);
+            
+            loopState.loopStartPoint = compiler.CurrentChunkInstructinCount;
+            loopState.loopContinuePoint = compiler.CurrentChunkInstructinCount;
+            {
+                //confirm that the index isn't over the length of the array
+                IsIndexLessThanArrayCount(compiler, arrayGetOp, arrayArgId, indexArgID);
+
+                //run the condition 
+                var exitJump = compiler.EmitJumpIf();
+                loopState.loopExitPatchLocations.Add(exitJump);
+                compiler.EmitOpCode(OpCode.POP); // Condition.
+            }
+            //increment
+            var bodyJump = compiler.GoToUniqueChunkLabel("inc_body");
+            {
+                var incrementStart = compiler.CurrentChunkInstructinCount;
+                loopState.loopContinuePoint = incrementStart;
+                IncrementLocalByOne(compiler, indexArgID);
+                compiler.EmitLoop(loopState.loopStartPoint);
+                loopState.loopStartPoint = incrementStart;
+                compiler.EmitLabel(bodyJump);
+            }
+            compiler.TokenIterator.Consume(TokenType.CLOSE_PAREN, "Expect ')' after loop clauses.");
+
+            //prep item infront of body
+            {
+                compiler.EmitOpAndBytes(arrayGetOp, arrayArgId);
+                compiler.EmitOpAndBytes(OpCode.GET_LOCAL, indexArgID);
+                compiler.EmitOpCode(OpCode.GET_INDEX);
+                compiler.EmitOpAndBytes(OpCode.SET_LOCAL, itemArgID);
+                compiler.EmitOpCode(OpCode.POP);
+            }
         }
 
         public static void IsIndexLessThanArrayCount(Compiler compiler, OpCode arrayGetOp, byte arrayArgId, byte indexArgID)
@@ -118,6 +112,10 @@
             compiler.EmitOpCode(OpCode.ADD);
             compiler.EmitOpAndBytes(OpCode.SET_LOCAL, indexArgID);
             compiler.EmitOpCode(OpCode.POP);
+        }
+
+        protected override void PreLoop(Compiler compiler, CompilerState.LoopState loopState)
+        {
         }
     }
 }

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/LoopStatementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/LoopStatementCompilette.cs
@@ -63,8 +63,8 @@
             compiler.EmitOpAndBytes(OpCode.SET_LOCAL, indexArgID);
             compiler.EmitNULL();
             compiler.EmitOpAndBytes(OpCode.SET_LOCAL, itemArgID);
-            
-            loopState.loopStartPoint = compiler.CurrentChunkInstructinCount;
+
+            loopState.StartLabelID = compiler.LabelUniqueChunkLabel("loop_start");
             loopState.loopContinuePoint = compiler.CurrentChunkInstructinCount;
             {
                 //confirm that the index isn't over the length of the array
@@ -78,11 +78,12 @@
             //increment
             var bodyJump = compiler.GoToUniqueChunkLabel("inc_body");
             {
+                var newStartLabel = compiler.LabelUniqueChunkLabel("loop_start");
                 var incrementStart = compiler.CurrentChunkInstructinCount;
                 loopState.loopContinuePoint = incrementStart;
                 IncrementLocalByOne(compiler, indexArgID);
-                compiler.EmitLoop(loopState.loopStartPoint);
-                loopState.loopStartPoint = incrementStart;
+                compiler.EmitGoto(loopState.StartLabelID);
+                loopState.StartLabelID = newStartLabel;
                 compiler.EmitLabel(bodyJump);
             }
             compiler.TokenIterator.Consume(TokenType.CLOSE_PAREN, "Expect ')' after loop clauses.");

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/LoopStatementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/LoopStatementCompilette.cs
@@ -77,14 +77,14 @@
                     compiler.EmitOpCode(OpCode.POP); // Condition.
                 }
                 //increment
-                int bodyJump = compiler.EmitJump();
+                var bodyJump = compiler.GoToUniqueChunkLabel("inc_body");
                 {
                     int incrementStart = compiler.CurrentChunkInstructinCount;
                     loopState.loopContinuePoint = incrementStart;
                     IncrementLocalByOne(compiler, indexArgID);
                     compiler.EmitLoop(loopStart);
                     loopStart = incrementStart;
-                    compiler.PatchJump(bodyJump);
+                    compiler.EmitLabel(bodyJump);
                 }
                 compiler.TokenIterator.Consume(TokenType.CLOSE_PAREN, "Expect ')' after loop clauses.");
 

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/LoopStatementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/LoopStatementCompilette.cs
@@ -46,8 +46,8 @@
 
             //skip the loop if the target is null
             compiler.EmitOpAndBytes(arrayGetOp, arrayArgId);
-            int exitJumpArrayIsNullLocation = compiler.EmitJumpIf();
-            loopState.loopExitPatchLocations.Add(exitJumpArrayIsNullLocation);
+            compiler.EmitGotoIf(loopState.ExitLabelID);
+            loopState.HasExit = true;
             compiler.EmitOpCode(OpCode.POP);
 
             //refer to output of For_WhenLimitedIterations_ShouldPrint3Times 
@@ -71,12 +71,12 @@
                 IsIndexLessThanArrayCount(compiler, arrayGetOp, arrayArgId, indexArgID);
 
                 //run the condition 
-                var exitJump = compiler.EmitJumpIf();
-                loopState.loopExitPatchLocations.Add(exitJump);
+                compiler.EmitGotoIf(loopState.ExitLabelID);
+                loopState.HasExit = true;
                 compiler.EmitOpCode(OpCode.POP); // Condition.
             }
             //increment
-            var bodyJump = compiler.GoToUniqueChunkLabel("inc_body");
+            var bodyJump = compiler.GotoUniqueChunkLabel("inc_body");
             {
                 var newStartLabel = compiler.LabelUniqueChunkLabel("loop_start");
                 loopState.ContinueLabelID = newStartLabel;

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TestDeclarationCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TestDeclarationCompilette.cs
@@ -28,7 +28,7 @@ namespace ULox
 
             //testbody
             compiler.BeginScope();
-            var labelID = compiler.GoToUniqueChunkLabel($"Test_{testClassName}");
+            var labelID = compiler.GotoUniqueChunkLabel($"Test_{testClassName}");
             var testFixtureBodyFirstInstruction = (ushort)compiler.CurrentChunkInstructinCount;
 
             compiler.Block();

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TestDeclarationCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TestDeclarationCompilette.cs
@@ -28,13 +28,13 @@ namespace ULox
 
             //testbody
             compiler.BeginScope();
-            var testFixtureBodyJumpLoc = compiler.EmitJump();
+            var labelID = compiler.GoToUniqueChunkLabel($"Test_{testClassName}");
             var testFixtureBodyFirstInstruction = (ushort)compiler.CurrentChunkInstructinCount;
 
             compiler.Block();
             compiler.EmitOpCode(OpCode.YIELD);
             compiler.EndScope();
-            compiler.PatchJump(testFixtureBodyJumpLoc);
+            compiler.EmitLabel(labelID);
 
             var testcaseCount = _currentTestcaseInstructions.Count;
             if (testcaseCount > byte.MaxValue)

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TestcaseCompillette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TestcaseCompillette.cs
@@ -26,7 +26,7 @@
             if (compiler.TokenIterator.Match(TokenType.OPEN_PAREN))
             {
                 //jump
-                var dataExpJumpID = compiler.GoToUniqueChunkLabel($"DataExpJump_{_testDeclarationCompilette.CurrentTestSetName}");
+                var dataExpJumpID = compiler.GotoUniqueChunkLabel($"DataExpJump_{_testDeclarationCompilette.CurrentTestSetName}");
                 //note location
                 dataExpExecuteLocation = compiler.LabelUniqueChunkLabel("DataExpExecuteLocation");
 
@@ -44,7 +44,7 @@
                 compiler.EmitOpCode(OpCode.POP);
 
                 //jump for moving back to start
-                dataExpJumpBackToStart = compiler.GoToUniqueChunkLabel($"DataExpJumpBackToStart_{_testDeclarationCompilette.CurrentTestSetName}");
+                dataExpJumpBackToStart = compiler.GotoUniqueChunkLabel($"DataExpJumpBackToStart_{_testDeclarationCompilette.CurrentTestSetName}");
 
                 //patch data jump
                 compiler.EmitLabel(dataExpJumpID);
@@ -64,7 +64,7 @@
             var nameConstantID = compiler.CurrentChunk.AddConstant(Value.New(testcaseName));
 
             //emit jump // to skip this during imperative
-            var testFragmentJump = compiler.GoToUniqueChunkLabel("testFragmentJump");
+            var testFragmentJump = compiler.GotoUniqueChunkLabel("testFragmentJump");
 
             _testDeclarationCompilette.AddTestCaseInstruction((ushort)compiler.CurrentChunkInstructinCount);
 
@@ -91,7 +91,7 @@
                 preRowCountCheck = compiler.LabelUniqueChunkLabel("preRowCountCheck");
 
                 LoopStatementCompilette.IsIndexLessThanArrayCount(compiler, OpCode.GET_LOCAL, testDataSourceLocalId, testDataIndexLocalId);
-                exitDataLoopJumpLoc = compiler.EmitJumpIf();
+                exitDataLoopJumpLoc = compiler.GotoIfUniqueChunkLabel("exitDataLoopJumpLoc");
                 compiler.EmitOpCode(OpCode.POP); // Condition.
 
                 //get row from array index
@@ -116,7 +116,7 @@
             {
                 LoopStatementCompilette.IncrementLocalByOne(compiler, testDataIndexLocalId);
                 compiler.EmitGoto((byte)preRowCountCheck);
-                compiler.PatchJump(exitDataLoopJumpLoc);
+                compiler.EmitLabel((byte)exitDataLoopJumpLoc);
             }
 
             compiler.EmitNULL();

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TypePropertyCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TypePropertyCompilette.cs
@@ -54,7 +54,7 @@ namespace ULox
                 _classVarConstantNames.Add(nameConstant);
 
                 //emit jump // to skip this during imperative
-                var initFragmentJump = compiler.GoToUniqueChunkLabel("SkipInitDuringImperative");
+                var initFragmentJump = compiler.GotoUniqueChunkLabel("SkipInitDuringImperative");
                 //patch jump previous init fragment if it exists
                 if (_previousInitFragLabelId != -1)
                 {
@@ -82,7 +82,7 @@ namespace ULox
                 compiler.EmitOpAndBytes(OpCode.SET_PROPERTY, nameConstant);
                 compiler.EmitOpCode(OpCode.POP);
                 //emit jump // to move to next prop init fragment, defaults to jump nowhere return
-                _previousInitFragLabelId = compiler.GoToUniqueChunkLabel("InitFragmentJump");
+                _previousInitFragLabelId = compiler.GotoUniqueChunkLabel("InitFragmentJump");
 
                 //patch jump from skip imperative
                 compiler.EmitLabel(initFragmentJump);
@@ -102,7 +102,7 @@ namespace ULox
                 compiler.WriteUShortAt(_typeCompilette.InitChainInstruction, (ushort)_initFragStartLocation);
 
             //return stub used by init and test chains
-            var classReturnEnd = compiler.GoToUniqueChunkLabel("ClassReturnEnd");
+            var classReturnEnd = compiler.GotoUniqueChunkLabel("ClassReturnEnd");
 
             if (_previousInitFragLabelId != -1)
                 compiler.EmitLabel((byte)_previousInitFragLabelId);

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/WhileStatementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/WhileStatementCompilette.cs
@@ -13,9 +13,8 @@
 
             compiler.Expression();
 
-            int exitJump = compiler.EmitJumpIf();
-            loopState.loopExitPatchLocations.Add(exitJump);
-
+            compiler.EmitGotoIf(loopState.ExitLabelID);
+            loopState.HasExit = true;
             compiler.EmitOpCode(OpCode.POP);
             
             compiler.TokenIterator.Consume(TokenType.CLOSE_PAREN, "Expect ')' after loop clauses.");

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/WhileStatementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/WhileStatementCompilette.cs
@@ -7,7 +7,7 @@
         {
         }
 
-        protected override int BeginLoop(Compiler compiler, int loopStart, CompilerState.LoopState loopState)
+        protected override void BeginLoop(Compiler compiler, CompilerState.LoopState loopState)
         {
             compiler.TokenIterator.Consume(TokenType.OPEN_PAREN, "Expect '(' after loop with conditions.");
 
@@ -19,8 +19,10 @@
             compiler.EmitOpCode(OpCode.POP);
             
             compiler.TokenIterator.Consume(TokenType.CLOSE_PAREN, "Expect ')' after loop clauses.");
+        }
 
-            return loopStart;
+        protected override void PreLoop(Compiler compiler, CompilerState.LoopState loopState)
+        {
         }
     }
 }

--- a/ulox/ulox.core/Package/Runtime/Engine/Disassembler.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/Disassembler.cs
@@ -88,6 +88,7 @@ namespace ULox
             opCodeHandlers[(int)OpCode.EXPECT] = AppendNothing;
 
             opCodeHandlers[(int)OpCode.GOTO] = AppendStringConstant;
+            opCodeHandlers[(int)OpCode.GOTO_IF_FALSE] = AppendStringConstant;
             opCodeHandlers[(int)OpCode.LABEL] = AppendStringConstant;
         }
 

--- a/ulox/ulox.core/Package/Runtime/Engine/Disassembler.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/Disassembler.cs
@@ -86,6 +86,9 @@ namespace ULox
             opCodeHandlers[(int)OpCode.COUNT_OF] = AppendNothing;
 
             opCodeHandlers[(int)OpCode.EXPECT] = AppendNothing;
+
+            opCodeHandlers[(int)OpCode.GOTO] = AppendStringConstant;
+            opCodeHandlers[(int)OpCode.LABEL] = AppendStringConstant;
         }
 
         public string GetString() => stringBuilder.ToString();
@@ -110,9 +113,25 @@ namespace ULox
             }
 
             var subChunks = new List<Chunk>();
-
+            
+            DoLabels(chunk);
             DoConstants(chunk, subChunks);
             DoSubChunks(subChunks);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void DoLabels(Chunk chunk)
+        {
+            if (chunk.Labels.Count > 0)
+            {
+                stringBuilder.AppendLine();
+                stringBuilder.AppendLine("--labels--");
+
+                foreach (var label in chunk.Labels)
+                {
+                    stringBuilder.AppendLine($"{chunk.ReadConstant(label.Key)} = {label.Value}");
+                }
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/ulox/ulox.core/Package/Runtime/Engine/VM.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/VM.cs
@@ -452,7 +452,15 @@ namespace ULox
                 case OpCode.EXPECT:
                     DoExpectOp();
                     break;
-                    
+
+                case OpCode.GOTO:
+                    DoGotoOp(chunk);
+                    break;
+
+                case OpCode.LABEL:
+                    ReadByte(chunk);
+                    break;
+                
                 case OpCode.NONE:
                 default:
                     ThrowRuntimeException($"Unhandled OpCode '{opCode}'.");
@@ -549,6 +557,15 @@ namespace ULox
             {
                 ThrowRuntimeException($"Expect failed, got {(msg.IsNull() ? "falsey" : msg.ToString())}");
             }
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void DoGotoOp(Chunk chunk)
+        {
+            var labelID = ReadByte(chunk);
+            var labelPos = chunk.GetLabelPosition(labelID);
+
+            _currentCallFrame.InstructionPointer = labelPos;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/ulox/ulox.core/Package/Runtime/Engine/VM.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/VM.cs
@@ -457,6 +457,10 @@ namespace ULox
                     DoGotoOp(chunk);
                     break;
 
+                case OpCode.GOTO_IF_FALSE:
+                    DoGotoIfFalseOp(chunk);
+                    break;
+
                 case OpCode.LABEL:
                     ReadByte(chunk);
                     break;
@@ -566,6 +570,16 @@ namespace ULox
             var labelPos = chunk.GetLabelPosition(labelID);
 
             _currentCallFrame.InstructionPointer = labelPos;
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void DoGotoIfFalseOp(Chunk chunk)
+        {
+            var labelID = ReadByte(chunk);
+            var labelPos = chunk.GetLabelPosition(labelID);
+
+            if (Peek().IsFalsey())
+                _currentCallFrame.InstructionPointer = labelPos;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/ulox/ulox.core/Package/Runtime/Enums/OpCode.cs
+++ b/ulox/ulox.core/Package/Runtime/Enums/OpCode.cs
@@ -83,6 +83,7 @@
         EXPECT,
 
         GOTO,
+        GOTO_IF_FALSE,
         LABEL,
     }
 }

--- a/ulox/ulox.core/Package/Runtime/Enums/OpCode.cs
+++ b/ulox/ulox.core/Package/Runtime/Enums/OpCode.cs
@@ -81,5 +81,8 @@
         COUNT_OF,
 
         EXPECT,
+
+        GOTO,
+        LABEL,
     }
 }

--- a/ulox/ulox.core/Package/Runtime/Enums/TokenType.cs
+++ b/ulox/ulox.core/Package/Runtime/Enums/TokenType.cs
@@ -102,5 +102,8 @@
         EXPECT,
 
         MATCH,
+
+        LABEL,
+        GOTO
     }
 }

--- a/ulox/ulox.core/Package/Runtime/Scanner/Scanner.cs
+++ b/ulox/ulox.core/Package/Runtime/Scanner/Scanner.cs
@@ -85,7 +85,10 @@ namespace ULox
 
                 ("data", TokenType.DATA),
 
-                ("match", TokenType.MATCH));
+                ("match", TokenType.MATCH),
+
+                ("label", TokenType.LABEL),
+                ("goto", TokenType.GOTO));
 
             this.AddSingleCharTokenGenerators(
                 ('(', TokenType.OPEN_PAREN),

--- a/ulox/ulox.core/Package/Runtime/Types/Chunk.cs
+++ b/ulox/ulox.core/Package/Runtime/Types/Chunk.cs
@@ -14,11 +14,13 @@ namespace ULox
         private const string DefaultChunkName = "unnamed_chunk";
         private readonly List<Value> constants = new List<Value>();
         private readonly List<RunLengthLineNumber> _runLengthLineNumbers = new List<RunLengthLineNumber>();
+        private readonly Dictionary<byte, int> _labelIdToInstruction = new Dictionary<byte, int>();
         private int instructionCount = -1;
 
         public List<byte> Instructions { get; private set; } = new List<byte>();
         public List<byte> ArgumentConstantIds { get; private set; } = new List<byte>();
         public IReadOnlyList<Value> Constants => constants.AsReadOnly();
+        public IReadOnlyDictionary<byte, int> Labels => _labelIdToInstruction;
         public string Name { get; set; }
         public string SourceName { get; private set; }
         public FunctionType FunctionType { get; internal set; }
@@ -155,6 +157,16 @@ namespace ULox
             }
 
             return locationName;
+        }
+
+        internal int GetLabelPosition(byte labelID)
+        {
+            return _labelIdToInstruction[labelID];
+        }
+
+        internal void AddLabel(byte id, int currentChunkInstructinCount)
+        {
+            _labelIdToInstruction[id] = currentChunkInstructinCount;
         }
     }
 }


### PR DESCRIPTION
Replace compilers use of jumps with labels, in future optimisation stage would reorg and remove this if it found it worthwhile.

close  #143 