### PR TITLE
Expand Math and Compare ops

### DIFF
--- a/ulox/ulox.core.tests/ByteCodeEngineTests.cs
+++ b/ulox/ulox.core.tests/ByteCodeEngineTests.cs
@@ -994,7 +994,7 @@ var c = b + a;
 "
             );
 
-            Assert.AreEqual(@"Cannot perform math op across types 'Double' and 'Null' at ip:'7' in chunk:'unnamed_chunk(test:4)'.
+            Assert.AreEqual(@"Cannot perform op across types 'Double' and 'Null' at ip:'7' in chunk:'unnamed_chunk(test:4)'.
 ===Stack===
 <closure unnamed_chunk upvals:0>
 
@@ -1016,7 +1016,7 @@ var c = b + a;
 f(null,1);"
             );
 
-            Assert.AreEqual(@"Cannot perform math op across types 'Double' and 'Null' at ip:'3' in chunk:'f(test:5)'.
+            Assert.AreEqual(@"Cannot perform op across types 'Double' and 'Null' at ip:'3' in chunk:'f(test:5)'.
 ===Stack===
 1
 null

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compiler.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compiler.cs
@@ -193,7 +193,7 @@ namespace ULox
                         EmitPop(popCount);
                         popCount = 0;
                     }
-                    
+
                     EmitPacket(OpCode.CLOSE_UPVALUE);
                 }
                 else
@@ -206,7 +206,6 @@ namespace ULox
             if (popCount > 0)
             {
                 EmitPop(popCount);
-                popCount = 0;
             }
         }
 
@@ -367,8 +366,7 @@ namespace ULox
         {
             if (IsFunctionLocal())
             {
-                if (getOp != OpCode.GET_LOCAL
-                    || setOp != OpCode.SET_LOCAL)
+                if (getOp != OpCode.GET_LOCAL || setOp != OpCode.SET_LOCAL)
                     ThrowCompilerException($"Identifiier '{name}' could not be found locally in local function '{CurrentCompilerState.chunk.Name}'");
             }
         }
@@ -594,8 +592,10 @@ namespace ULox
         {
             while (!TokenIterator.Check(TokenType.CLOSE_BRACE)
                 && !TokenIterator.Check(TokenType.EOF))
+            {
                 Declaration();
-
+            }
+            
             TokenIterator.Consume(TokenType.CLOSE_BRACE, "Expect '}' after block.");
         }
 
@@ -629,7 +629,7 @@ namespace ULox
         {
             if (CurrentCompilerState.ResolveLocal(this, itemName) != -1)
                 ThrowCompilerException($"{errorPrefix} '{itemName}' already exists at this scope");
-            
+
             CurrentCompilerState.DeclareVariableByName(this, itemName);
             CurrentCompilerState.MarkInitialised();
             var itemArgId = (byte)CurrentCompilerState.ResolveLocal(this, itemName);
@@ -710,8 +710,7 @@ namespace ULox
                 compiler.EmitPacket(OpCode.EXPECT);
             }
             while (compiler.TokenIterator.Match(TokenType.COMMA));
-
-
+            
             compiler.ConsumeEndStatement();
         }
 
@@ -793,8 +792,8 @@ namespace ULox
                 if (isList)
                 {
                     var constantNameId = compiler.AddCustomStringConstant("Add");
-                    var argCount = (byte)1;
-                    compiler.EmitPacket(new ByteCodePacket(OpCode.INVOKE, constantNameId, argCount,0));
+                    const byte argCount = 1;
+                    compiler.EmitPacket(new ByteCodePacket(OpCode.INVOKE, constantNameId, argCount, 0));
                 }
                 else
                 {
@@ -841,7 +840,7 @@ namespace ULox
             else if (compiler.TokenIterator.Match(TokenType.OPEN_PAREN))
             {
                 var argCount = compiler.ArgumentList();
-                compiler.EmitPacket(new ByteCodePacket(OpCode.INVOKE, nameId, argCount,0));
+                compiler.EmitPacket(new ByteCodePacket(OpCode.INVOKE, nameId, argCount, 0));
             }
             else
             {

--- a/ulox/ulox.core/Package/Runtime/Compiler/CompilerExt.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/CompilerExt.cs
@@ -39,9 +39,9 @@
 
         public static void SetPrattRules(this Compiler comp, params (TokenType tt, IParseRule rule)[] rules)
         {
-            foreach (var item in rules)
+            foreach (var (tt, rule) in rules)
             {
-                comp.SetPrattRule(item.tt, item.rule);
+                comp.SetPrattRule(tt, rule);
             }
         }
     }

--- a/ulox/ulox.core/Package/Runtime/Compiler/CompilerState.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/CompilerState.cs
@@ -13,7 +13,7 @@ namespace ULox
                 Depth = depth;
             }
 
-            public string Name { get; private set; }
+            public string Name { get; }
             public int Depth { get; set; }
             public bool IsCaptured { get; set; }
         }
@@ -57,7 +57,7 @@ namespace ULox
             functionType = funcType;
         }
 
-        public Stack<LoopState> LoopStates { get; private set; } = new Stack<LoopState>();
+        public Stack<LoopState> LoopStates { get; } = new Stack<LoopState>();
         private Local LastLocal => locals[localCount - 1];
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -90,12 +90,9 @@ namespace ULox
         public int AddUpvalue(Compiler compiler, byte index, bool isLocal)
         {
             int upvalueCount = chunk.UpvalueCount;
-
-            Upvalue upvalue = default;
-
             for (int i = 0; i < upvalueCount; i++)
             {
-                upvalue = upvalues[i];
+                Upvalue upvalue = upvalues[i];
                 if (upvalue.index == index && upvalue.isLocal == isLocal)
                 {
                     return i;

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ActionParseRule.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ActionParseRule.cs
@@ -2,9 +2,9 @@
 {
     public class ActionParseRule : IParseRule
     {
-        public System.Action<Compiler, bool> PrefixAction { get; private set; }
-        public System.Action<Compiler, bool> InfixAction { get; private set; }
-        public Precedence Precedence { get; private set; }
+        public System.Action<Compiler, bool> PrefixAction { get; }
+        public System.Action<Compiler, bool> InfixAction { get; }
+        public Precedence Precedence { get; }
 
         public ActionParseRule(
             System.Action<Compiler, bool> prefix,

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/CompiletteAction.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/CompiletteAction.cs
@@ -14,7 +14,7 @@ namespace ULox
             Match = match;
         }
 
-        public TokenType Match { get; private set; }
+        public TokenType Match { get; }
 
         public void Process(Compiler compiler)
             => processAction.Invoke(compiler);

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ConfigurableLoopingStatementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ConfigurableLoopingStatementCompilette.cs
@@ -4,7 +4,7 @@ namespace ULox
 {
     public abstract class ConfigurableLoopingStatementCompilette : ICompilette
     {
-        public TokenType Match { get; private set; }
+        public TokenType Match { get; }
 
         protected ConfigurableLoopingStatementCompilette(TokenType match)
         {

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ReturnStatementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ReturnStatementCompilette.cs
@@ -7,7 +7,7 @@ namespace ULox
         public TokenType Match => TokenType.RETURN;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void ReturnStatement(Compiler compiler)
+        public static void ReturnStatement(Compiler compiler)
         {
             //TODO refactor out
             if (compiler.CurrentCompilerState.functionType == FunctionType.Init)
@@ -22,7 +22,7 @@ namespace ULox
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void SimpleReturnBody(Compiler compiler)
+        private static void SimpleReturnBody(Compiler compiler)
         {
             if (compiler.TokenIterator.Check(TokenType.END_STATEMENT))
             {
@@ -36,7 +36,7 @@ namespace ULox
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void MultiReturnBody(Compiler compiler)
+        private static void MultiReturnBody(Compiler compiler)
         {
             compiler.EmitPacket(new ByteCodePacket(OpCode.RETURN, ReturnMode.Begin));
             var returnCount = compiler.ExpressionList(TokenType.CLOSE_PAREN, "Expect ')' after arguments.");

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TypeCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TypeCompilette.cs
@@ -67,24 +67,11 @@ namespace ULox
             TypeCompiletteStage.Complete
         };
 
-        private static readonly TypeCompiletteStage[] PostBodyCompileStageOrder = new[]
-        {
-            TypeCompiletteStage.Invalid,
-            TypeCompiletteStage.Begin,
-            TypeCompiletteStage.Static,
-            TypeCompiletteStage.Mixin,
-            TypeCompiletteStage.Var,
-            TypeCompiletteStage.Init,
-            TypeCompiletteStage.Method,
-            TypeCompiletteStage.Signs,
-            TypeCompiletteStage.Complete
-        };
-
         public TokenType Match { get; private set; }
 
         public static readonly HashedString InitMethodName = new HashedString("init");
 
-        private Dictionary<TokenType, ITypeBodyCompilette> _innerDeclarationCompilettes = new Dictionary<TokenType, ITypeBodyCompilette>();
+        private readonly Dictionary<TokenType, ITypeBodyCompilette> _innerDeclarationCompilettes = new Dictionary<TokenType, ITypeBodyCompilette>();
         private ITypeBodyCompilette _bodyCompiletteFallback;
 
         private TypeCompiletteStage _stage = TypeCompiletteStage.Invalid;
@@ -95,7 +82,6 @@ namespace ULox
         public bool IsFrozenAtEnd { get; set; } = true;
         public bool IsReadOnlyAtEnd { get; set; } = false;
         private ITypeBodyCompilette[] BodyCompilettesProcessingOrdered;
-        private ITypeBodyCompilette[] BodyCompilettesPostBodyOrdered;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AddInnerDeclarationCompilette(ITypeBodyCompilette compilette)
@@ -161,9 +147,6 @@ namespace ULox
         {
             BodyCompilettesProcessingOrdered = _innerDeclarationCompilettes.Values
                 .OrderBy(x => System.Array.IndexOf(BodyCompileStageOrder, x.Stage))
-                .ToArray();
-            BodyCompilettesPostBodyOrdered = _innerDeclarationCompilettes.Values
-                .OrderBy(x => System.Array.IndexOf(PostBodyCompileStageOrder, x.Stage))
                 .ToArray();
         }
 

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TypeSignsCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TypeSignsCompilette.cs
@@ -27,7 +27,7 @@ namespace ULox
 
             compiler.ConsumeEndStatement("signs declaration");
 
-            _typeCompilette.OnPostBody += x =>
+            _typeCompilette.OnPostBody += (_) =>
             {
                 foreach (var contractName in contractNames)
                 {

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TypeStaticElementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TypeStaticElementCompilette.cs
@@ -16,7 +16,7 @@
                 StaticMethod(compiler);
         }
 
-        protected void StaticProperty(Compiler compiler)
+        protected static void StaticProperty(Compiler compiler)
         {
             do
             {
@@ -44,7 +44,7 @@
             compiler.ConsumeEndStatement();
         }
 
-        protected void StaticMethod(Compiler compiler)
+        protected static void StaticMethod(Compiler compiler)
         {
             compiler.TokenIterator.Consume(TokenType.IDENTIFIER, "Expect method name.");
             byte constant = compiler.AddStringConstant();

--- a/ulox/ulox.core/Package/Runtime/Engine/ByteCodePacket.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/ByteCodePacket.cs
@@ -3,10 +3,10 @@
 namespace ULox
 {
     [StructLayout(LayoutKind.Explicit)]
-    public struct ByteCodePacket
+    public readonly struct ByteCodePacket
     {
         [StructLayout(LayoutKind.Explicit)]
-        public struct TestOpDetails
+        public readonly struct TestOpDetails
         {
             public TestOpType TestOpType => (TestOpType)_testOp;
 
@@ -26,7 +26,7 @@ namespace ULox
         }
 
         [StructLayout(LayoutKind.Explicit)]
-        public struct ClosureDetails
+        public readonly struct ClosureDetails
         {
             public ClosureType ClosureType => (ClosureType)_type;
 
@@ -46,16 +46,16 @@ namespace ULox
         }
 
         [StructLayout(LayoutKind.Explicit)]
-        public struct TypeDetails
+        public readonly struct TypeDetails
         {
             public UserType UserType => (UserType)_userType;
 
             [FieldOffset(0)]
-            public byte stringConstantId;
+            public readonly byte stringConstantId;
             [FieldOffset(1)]
-            public byte _userType;
+            public readonly byte _userType;
             [FieldOffset(2)]
-            public byte initLabelId;
+            public readonly byte initLabelId;
 
             public TypeDetails(byte nameConstant, UserType userType, byte initChainLabelId) : this()
             {

--- a/ulox/ulox.core/Package/Runtime/Engine/Context.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/Context.cs
@@ -18,9 +18,9 @@ namespace ULox
             Vm = vm;
         }
 
-        public IScriptLocator ScriptLocator { get; private set; }
-        public Program Program { get; private set; }
-        public Vm Vm { get; private set; }
+        public IScriptLocator ScriptLocator { get; }
+        public Program Program { get; }
+        public Vm Vm { get; }
         public event Action<string> OnLog;
 
         public void AddLibrary(IULoxLibrary lib)

--- a/ulox/ulox.core/Package/Runtime/Engine/Disassembler.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/Disassembler.cs
@@ -64,7 +64,7 @@ namespace ULox
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void AppendSpace()
         {
-            stringBuilder.Append(" ");
+            stringBuilder.Append(' ');
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/ulox/ulox.core/Package/Runtime/Engine/Engine.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/Engine.cs
@@ -5,7 +5,7 @@ namespace ULox
 {
     public sealed class Engine
     {
-        public Context Context { get; private set; }
+        public Context Context { get; }
         public readonly Queue<Script> _buildQueue = new Queue<Script>();
 
         public Engine(Context executionContext)

--- a/ulox/ulox.core/Package/Runtime/Engine/Program.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/Program.cs
@@ -8,11 +8,10 @@ namespace ULox
     {
         private readonly Scanner _scanner = new Scanner();
         private readonly Compiler _compiler = new Compiler();
-        private readonly ByteCodeOptimiser _optimiser = new ByteCodeOptimiser();
 
-        public List<CompiledScript> CompiledScripts { get; private set; } = new List<CompiledScript>();
+        public List<CompiledScript> CompiledScripts { get; } = new List<CompiledScript>();
 
-        public ByteCodeOptimiser Optimiser => _optimiser;
+        public ByteCodeOptimiser Optimiser { get; } = new ByteCodeOptimiser();
 
         public string Disassembly
         {
@@ -33,18 +32,18 @@ namespace ULox
         {
             var hash = script.GetHashCode();
 
-            var existing = CompiledScripts.FirstOrDefault(x => x.ScriptHash == hash);
+            var existing = CompiledScripts.Find(x => x.ScriptHash == hash);
             if (existing != null)
                 return existing;
 
             _scanner.Reset();
             _compiler.Reset();
-            _optimiser.Reset();
+            Optimiser.Reset();
             
             var compiled = _compiler.Compile(_scanner, script);
             
             CompiledScripts.Add(compiled);
-            _optimiser.Optimise(compiled);
+            Optimiser.Optimise(compiled);
             
             return compiled;
         }

--- a/ulox/ulox.core/Package/Runtime/Engine/ScriptLocator.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/ScriptLocator.cs
@@ -17,7 +17,7 @@ namespace ULox
         public Script Find(string name)
         {
             var externalMatches = Directory.GetFiles(_directory.FullName, $"{name}*");
-            if (externalMatches != null && externalMatches.Length > 0)
+            if (externalMatches?.Length > 0)
                 return new Script(name, File.ReadAllText(externalMatches[0]));
             
             return new Script(name,String.Empty);

--- a/ulox/ulox.core/Package/Runtime/Engine/TestRunner.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/TestRunner.cs
@@ -21,7 +21,7 @@ namespace ULox
         public bool AllPassed => !_testStatus.Any(x => !x.Value);
         public int TestsFound => _testStatus.Count;
         public HashedString CurrentTestSetName { get; set; } = new HashedString(string.Empty);
-        public Func<Vm> CreateVM { get; private set; }
+        public Func<Vm> CreateVM { get; }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void StartTest(Vm vm, string name)
@@ -125,7 +125,7 @@ namespace ULox
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private string ArgDescriptionString(Vm vm, byte argCount)
+        private static string ArgDescriptionString(Vm vm, byte argCount)
         {
             var sb = new StringBuilder();
             for (int i = argCount - 1; i >= 0; i--)

--- a/ulox/ulox.core/Package/Runtime/Engine/VM.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/VM.cs
@@ -265,20 +265,54 @@ namespace ULox
                         break;
                     }
 
-                    if (lhs.type != rhs.type)
-                        ThrowRuntimeException($"Cannot perform math op across types '{lhs.type}' and '{rhs.type}'");
-
-                    if (lhs.type != ValueType.Instance)
-                        ThrowRuntimeException($"Cannot perform math op on non math types '{lhs.type}' and '{rhs.type}'");
-
-                    if (!DoCustomOverloadOp(opCode, lhs, rhs, Value.Null()))
-                        ThrowRuntimeException($"Cannot perform math op '{opCode}' on user types '{lhs.val.asInstance.FromUserType}' and '{rhs.val.asInstance.FromUserType}'");
-
+                    DoInstanceOverload(opCode, rhs, lhs);
                 }
                 break;
                 case OpCode.SUBTRACT:
+                {
+                    var rhs = Pop();
+                    var lhs = Pop();
+
+                    if (lhs.type == ValueType.Double
+                        && rhs.type == ValueType.Double)
+                    {
+                        Push(Value.New(lhs.val.asDouble - rhs.val.asDouble));
+                        break;
+                    }
+
+                    DoInstanceOverload(opCode, rhs, lhs);
+                }
+                break;
                 case OpCode.MULTIPLY:
+                {
+                    var rhs = Pop();
+                    var lhs = Pop();
+
+                    if (lhs.type == ValueType.Double
+                        && rhs.type == ValueType.Double)
+                    {
+                        Push(Value.New(lhs.val.asDouble * rhs.val.asDouble));
+                        break;
+                    }
+
+                    DoInstanceOverload(opCode, rhs, lhs);
+                }
+                break;
                 case OpCode.DIVIDE:
+                {
+                    var rhs = Pop();
+                    var lhs = Pop();
+
+                    if (lhs.type == ValueType.Double
+                        && rhs.type == ValueType.Double)
+                    {
+                        Push(Value.New(lhs.val.asDouble / rhs.val.asDouble));
+                        break;
+                    }
+
+                    DoInstanceOverload(opCode, rhs, lhs);
+                }
+                break;
                 case OpCode.MODULUS:
                 {
                     var rhs = Pop();
@@ -287,38 +321,11 @@ namespace ULox
                     if (lhs.type == ValueType.Double
                         && rhs.type == ValueType.Double)
                     {
-                        var res = Value.New(0);
-                        switch (opCode)
-                        {
-                        case OpCode.SUBTRACT:
-                            res.val.asDouble = lhs.val.asDouble - rhs.val.asDouble;
-                            break;
-
-                        case OpCode.MULTIPLY:
-                            res.val.asDouble = lhs.val.asDouble * rhs.val.asDouble;
-                            break;
-
-                        case OpCode.DIVIDE:
-                            res.val.asDouble = lhs.val.asDouble / rhs.val.asDouble;
-                            break;
-
-                        case OpCode.MODULUS:
-                            res.val.asDouble = lhs.val.asDouble % rhs.val.asDouble;
-                            break;
-                        }
-                        Push(res);
+                        Push(Value.New(lhs.val.asDouble % rhs.val.asDouble));
                         break;
                     }
 
-                    if (lhs.type != rhs.type)
-                        ThrowRuntimeException($"Cannot perform math op across types '{lhs.type}' and '{rhs.type}'");
-
-                    if (lhs.type != ValueType.Instance)
-                        ThrowRuntimeException($"Cannot perform math op on non math types '{lhs.type}' and '{rhs.type}'");
-
-                    if (!DoCustomOverloadOp(opCode, lhs, rhs, Value.Null()))
-                        ThrowRuntimeException($"Cannot perform math op '{opCode}' on user types '{lhs.val.asInstance.FromUserType}' and '{rhs.val.asInstance.FromUserType}'");
-
+                    DoInstanceOverload(opCode, rhs, lhs);
                 }
                 break;
 
@@ -327,11 +334,14 @@ namespace ULox
                     var rhs = Pop();
                     var lhs = Pop();
 
-                    if (lhs.type == ValueType.Instance
-                        && DoCustomOverloadOp(opCode, lhs, rhs, Value.Null()))
+                    if (lhs.type != ValueType.Instance)
+                    {
+                        Push(Value.New(Value.Compare(ref lhs, ref rhs)));
                         break;
+                    }
 
-                    Push(Value.New(Value.Compare(ref lhs, ref rhs)));
+                    if (!DoCustomOverloadOp(opCode, lhs, rhs, Value.Null()))
+                        Push(Value.New(Value.Compare(ref lhs, ref rhs)));
                 }
                 break;
 
@@ -340,15 +350,16 @@ namespace ULox
                     var rhs = Pop();
                     var lhs = Pop();
 
-                    if (lhs.type == ValueType.Instance
-                        && DoCustomOverloadOp(opCode, lhs, rhs, Value.Null()))
+                    if (lhs.type != ValueType.Instance)
+                    {
+                        if (lhs.type != ValueType.Double || rhs.type != ValueType.Double)
+                            ThrowRuntimeException($"Cannot '{opCode}' compare on different types '{lhs.type}' and '{rhs.type}'");
+
+                        Push(Value.New(lhs.val.asDouble < rhs.val.asDouble));
                         break;
+                    }
 
-                    if (lhs.type != ValueType.Double || rhs.type != ValueType.Double)
-                        ThrowRuntimeException($"Cannot '{opCode}' compare on different types '{lhs.type}' and '{rhs.type}'");
-
-                    Push(Value.New(lhs.val.asDouble < rhs.val.asDouble));
-
+                    DoInstanceOverload(opCode, rhs, lhs);
                 }
                 break;
                 case OpCode.GREATER:
@@ -356,14 +367,16 @@ namespace ULox
                     var rhs = Pop();
                     var lhs = Pop();
 
-                    if (lhs.type == ValueType.Instance
-                        && DoCustomOverloadOp(opCode, lhs, rhs, Value.Null()))
+                    if (lhs.type != ValueType.Instance)
+                    {
+                        if (lhs.type != ValueType.Double || rhs.type != ValueType.Double)
+                            ThrowRuntimeException($"Cannot '{opCode}' compare on different types '{lhs.type}' and '{rhs.type}'");
+
+                        Push(Value.New(lhs.val.asDouble > rhs.val.asDouble));
                         break;
+                    }
 
-                    if (lhs.type != ValueType.Double || rhs.type != ValueType.Double)
-                        ThrowRuntimeException($"Cannot '{opCode}' compare on different types '{lhs.type}' and '{rhs.type}'");
-
-                    Push(Value.New(lhs.val.asDouble > rhs.val.asDouble));
+                    DoInstanceOverload(opCode, rhs, lhs);
                 }
                 break;
 
@@ -597,6 +610,19 @@ namespace ULox
                     break;
                 }
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void DoInstanceOverload(OpCode opCode, Value rhs, Value lhs)
+        {
+            if (lhs.type != rhs.type)
+                ThrowRuntimeException($"Cannot perform op across types '{lhs.type}' and '{rhs.type}'");
+
+            if (lhs.type != ValueType.Instance)
+                ThrowRuntimeException($"Cannot perform op on non math types '{lhs.type}' and '{rhs.type}'");
+
+            if (!DoCustomOverloadOp(opCode, lhs, rhs, Value.Null()))
+                ThrowRuntimeException($"Cannot perform op '{opCode}' on user types '{lhs.val.asInstance.FromUserType}' and '{rhs.val.asInstance.FromUserType}'");
         }
 
         public void ThrowRuntimeException(string msg)

--- a/ulox/ulox.core/Package/Runtime/Library/Classes/NativeListClass.cs
+++ b/ulox/ulox.core/Package/Runtime/Library/Classes/NativeListClass.cs
@@ -63,7 +63,7 @@ namespace ULox
             return NativeCallResult.SuccessfulExpression;
         }
 
-        private void ThrowIfReadOnly(Vm vm)
+        private static void ThrowIfReadOnly(Vm vm)
         {
             var inst = vm.GetArg(0);
             var nativeListinst = inst.val.asInstance as NativeListInstance;

--- a/ulox/ulox.core/Package/Runtime/Library/Classes/NativeListInstance.cs
+++ b/ulox/ulox.core/Package/Runtime/Library/Classes/NativeListInstance.cs
@@ -5,14 +5,13 @@ namespace ULox
 {
     public sealed class NativeListInstance : InstanceInternal, INativeCollection
     {
-        private readonly List<Value> _list = new List<Value>();
 
         public NativeListInstance(UserTypeInternal fromClass)
             : base(fromClass)
         {
         }
 
-        public List<Value> List => _list;
+        public List<Value> List { get; } = new List<Value>();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Set(Value ind, Value val)
@@ -20,20 +19,20 @@ namespace ULox
             if (IsReadOnly)
                 throw new UloxException($"Attempted to Set index '{ind}' to '{val}', but list is read only.");
 
-            _list[(int)ind.val.asDouble] = val;
+            List[(int)ind.val.asDouble] = val;
         }
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Value Get(Value ind)
         {
-            return _list[(int)ind.val.asDouble];
+            return List[(int)ind.val.asDouble];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Value Count()
         {
-            return Value.New(_list.Count);
+            return Value.New(List.Count);
         }
     }
 }

--- a/ulox/ulox.core/Package/Runtime/Library/Classes/NativeMapClass.cs
+++ b/ulox/ulox.core/Package/Runtime/Library/Classes/NativeMapClass.cs
@@ -114,7 +114,7 @@ namespace ULox
             return NativeCallResult.SuccessfulExpression;
         }
 
-        private void ThrowIfReadOnly(Vm vm)
+        private static void ThrowIfReadOnly(Vm vm)
         {
             var inst = vm.GetArg(0);
             var nativeMapInstance = inst.val.asInstance as NativeMapInstance;

--- a/ulox/ulox.core/Package/Runtime/Library/Classes/NativeMapInstance.cs
+++ b/ulox/ulox.core/Package/Runtime/Library/Classes/NativeMapInstance.cs
@@ -5,7 +5,6 @@ namespace ULox
 {
     public sealed class NativeMapInstance : InstanceInternal, INativeCollection
     {
-        private readonly Dictionary<Value, Value> _map = new Dictionary<Value, Value>();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public NativeMapInstance(UserTypeInternal fromClass)
@@ -13,7 +12,7 @@ namespace ULox
         {
         }
 
-        public Dictionary<Value, Value> Map => _map;
+        public Dictionary<Value, Value> Map { get; } = new Dictionary<Value, Value>();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Set(Value ind, Value val)
@@ -21,13 +20,13 @@ namespace ULox
             if (IsReadOnly)
                 throw new UloxException($"Attempted to Set index '{ind}' to '{val}', but map is read only.");
 
-            _map[ind] = val;
+            Map[ind] = val;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Value Get(Value ind)
         {
-            return _map.TryGetValue(ind, out var value)
+            return Map.TryGetValue(ind, out var value)
                 ? value
                 : throw new UloxException($"Map contains no key of '{ind}'.");
         }
@@ -35,7 +34,7 @@ namespace ULox
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Value Count()
         {
-            return Value.New(_map.Count);
+            return Value.New(Map.Count);
         }
     }
 }

--- a/ulox/ulox.core/Package/Runtime/Library/Classes/VMClass.cs
+++ b/ulox/ulox.core/Package/Runtime/Library/Classes/VMClass.cs
@@ -6,7 +6,7 @@ namespace ULox
     {
         private static readonly HashedString VMFieldName = new HashedString("vm");
 
-        public Func<Vm> CreateVM { get; private set; }
+        public Func<Vm> CreateVM { get; }
 
         public VMClass(Func<Vm> createVM) : base(new HashedString("VM"), UserType.Native)
         {
@@ -78,7 +78,7 @@ namespace ULox
             return NativeCallResult.SuccessfulExpression;
         }
 
-        private Vm GetArg0Vm(Vm vm)
+        private static Vm GetArg0Vm(Vm vm)
         {
             var instVal = vm.GetArg(0);
             var inst = instVal.val.asInstance;

--- a/ulox/ulox.core/Package/Runtime/Library/Serialise/JsonDocValueHeirarchyTraverser.cs
+++ b/ulox/ulox.core/Package/Runtime/Library/Serialise/JsonDocValueHeirarchyTraverser.cs
@@ -6,7 +6,7 @@ namespace ULox
 {
     public class JsonDocValueHeirarchyTraverser : DocValueHeirarchyTraverser
     {
-        private JsonTextReader _reader;
+        private readonly JsonTextReader _reader;
 
         public JsonDocValueHeirarchyTraverser(
             IValueObjectBuilder valBuilder,

--- a/ulox/ulox.core/Package/Runtime/Library/Serialise/ValueObjectBuilder.cs
+++ b/ulox/ulox.core/Package/Runtime/Library/Serialise/ValueObjectBuilder.cs
@@ -9,7 +9,7 @@ namespace ULox
         private readonly ObjectType _objectType;
 
         private Value _value;
-        private List<(string name, ValueObjectBuilder builder)> _children = new List<(string, ValueObjectBuilder)>();
+        private readonly List<(string name, ValueObjectBuilder builder)> _children = new List<(string, ValueObjectBuilder)>();
 
         public ValueObjectBuilder(ObjectType ot)
         {
@@ -32,9 +32,9 @@ namespace ULox
         {
             for (int i = _children.Count - 1; i >= 0; i--)
             {
-                var item = _children[i];
-                var childVal = item.builder.Finish();
-                _value.val.asInstance.SetField(new HashedString(item.name), childVal);
+                var (name, builder) = _children[i];
+                var childVal = builder.Finish();
+                _value.val.asInstance.SetField(new HashedString(name), childVal);
             }
 
             return _value;

--- a/ulox/ulox.core/Package/Runtime/Library/StdLibrary.cs
+++ b/ulox/ulox.core/Package/Runtime/Library/StdLibrary.cs
@@ -7,7 +7,7 @@ namespace ULox
     {
         private const double SquareDividedTolerance = 0.01d;
         
-        public Func<Vm> CreateVM { get; private set; }
+        public Func<Vm> CreateVM { get; }
 
         public StdLibrary()
         {
@@ -78,7 +78,7 @@ namespace ULox
         {
             var lhs = vm.GetArg(1);
             var rhs = vm.GetArg(2);
-            if (!lhs.Compare(ref lhs, ref rhs))
+            if (!Value.Compare(ref lhs, ref rhs))
                 vm.ThrowRuntimeException($"'{lhs}' does not equal '{rhs}'");
 
             return NativeCallResult.SuccessfulExpression;
@@ -89,7 +89,7 @@ namespace ULox
         {
             var lhs = vm.GetArg(1);
             var rhs = vm.GetArg(2);
-            if (lhs.Compare(ref lhs, ref rhs))
+            if (Value.Compare(ref lhs, ref rhs))
                 vm.ThrowRuntimeException($"'{lhs}' does not NOT equal '{rhs}'");
 
             return NativeCallResult.SuccessfulExpression;
@@ -170,7 +170,7 @@ namespace ULox
             {
                 ourVM.Interpret(toRun);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 didThrow = true;
             }
@@ -196,28 +196,28 @@ namespace ULox
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public NativeCallResult GenerateStackDump(Vm vm, int argCount)
+        public static NativeCallResult GenerateStackDump(Vm vm, int argCount)
         {
             vm.PushReturn(Value.New(vm.GenerateValueStackDump()));
             return NativeCallResult.SuccessfulExpression;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public NativeCallResult GenerateGlobalsDump(Vm vm, int argCount)
+        public static NativeCallResult GenerateGlobalsDump(Vm vm, int argCount)
         {
             vm.PushReturn(Value.New(vm.GenerateGlobalsDump()));
             return NativeCallResult.SuccessfulExpression;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public NativeCallResult GenerateReturnDump(Vm vm, int argCount)
+        public static NativeCallResult GenerateReturnDump(Vm vm, int argCount)
         {
             vm.PushReturn(Value.New(vm.GenerateReturnDump()));
             return NativeCallResult.SuccessfulExpression;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public NativeCallResult IsFrozen(Vm vm, int argCount)
+        public static NativeCallResult IsFrozen(Vm vm, int argCount)
         {
             var target = vm.GetArg(1);
             if (target.type == ValueType.Instance)
@@ -229,7 +229,7 @@ namespace ULox
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public NativeCallResult Unfreeze(Vm vm, int argCount)
+        public static NativeCallResult Unfreeze(Vm vm, int argCount)
         {
             var target = vm.GetArg(1);
             if (target.type == ValueType.Instance)
@@ -241,7 +241,7 @@ namespace ULox
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public NativeCallResult str(Vm vm, int argCount)
+        public static NativeCallResult str(Vm vm, int argCount)
         {
             var v = vm.GetArg(1);
             vm.PushReturn(Value.New(v.str()));
@@ -249,7 +249,7 @@ namespace ULox
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public NativeCallResult Duplicate(Vm vm, int argCount)
+        public static NativeCallResult Duplicate(Vm vm, int argCount)
         {
             vm.PushReturn(Value.Copy(vm.GetArg(1)));
             return NativeCallResult.SuccessfulExpression;

--- a/ulox/ulox.core/Package/Runtime/Library/ULoxLibraryExt.cs
+++ b/ulox/ulox.core/Package/Runtime/Library/ULoxLibraryExt.cs
@@ -10,9 +10,9 @@ namespace ULox
             params (string name, Value val)[] bind)
         {
             var resTable = new Table();
-            foreach (var item in bind)
+            foreach (var (name, val) in bind)
             {
-                resTable.Add(new HashedString(item.name), item.val);
+                resTable.Add(new HashedString(name), val);
             }
             return resTable;
         }
@@ -22,9 +22,9 @@ namespace ULox
             this InstanceInternal self,
             params (string name, Value val)[] bind)
         {
-            foreach (var item in bind)
+            foreach (var (name, val) in bind)
             {
-                self.SetField(new HashedString(item.name), item.val);
+                self.SetField(new HashedString(name), val);
             }
         }
 
@@ -33,9 +33,9 @@ namespace ULox
             this UserTypeInternal self,
             params (string name, Value val)[] bind)
         {
-            foreach (var item in bind)
+            foreach (var (name, val) in bind)
             {
-                self.AddMethod(new HashedString(item.name), item.val, null);
+                self.AddMethod(new HashedString(name), val, null);
             }
         }
     }

--- a/ulox/ulox.core/Package/Runtime/Optimiser/ByteCodeOptimiser.cs
+++ b/ulox/ulox.core/Package/Runtime/Optimiser/ByteCodeOptimiser.cs
@@ -7,7 +7,7 @@ namespace ULox
     {
         public bool Enabled { get; set; } = false;
         private List<(Chunk chunk, int inst)> _toRemove = new List<(Chunk, int)>();
-        private List<(Chunk chunk, int from, byte label)> _labelUsage = new List<(Chunk, int, byte)>();
+        private readonly List<(Chunk chunk, int from, byte label)> _labelUsage = new List<(Chunk, int, byte)>();
         private OpCode _prevOoCode;
         private int _deadCodeStart = -1;
 
@@ -25,17 +25,17 @@ namespace ULox
 
         private void MarkNoJumpGotoLabelAsDead(CompiledScript compiledScript)
         {
-            foreach (var labelUsage in _labelUsage)
+            foreach (var (chunk, from, label) in _labelUsage)
             {
-                var labelLoc = labelUsage.chunk.Labels[labelUsage.label];
+                var labelLoc = chunk.Labels[label];
 
-                if (labelUsage.from - 1 >= labelLoc)
+                if (from - 1 >= labelLoc)
                     continue;
 
                 var found = false;
-                for (int i = labelUsage.from + 1; i < labelLoc; i++)
+                for (int i = from + 1; i < labelLoc; i++)
                 {
-                    if (!_toRemove.Any(d => d.chunk == labelUsage.chunk && d.inst == i))
+                    if (!_toRemove.Any(d => d.chunk == chunk && d.inst == i))
                     {
                         found = true;
                         break;
@@ -44,7 +44,7 @@ namespace ULox
 
                 if (!found)
                 {
-                    _toRemove.Add((labelUsage.chunk, labelUsage.from));
+                    _toRemove.Add((chunk, from));
                 }
             }
         }

--- a/ulox/ulox.core/Package/Runtime/Scanner/Generators/CompoundCharScannerCharMatchTokenGenerator.cs
+++ b/ulox/ulox.core/Package/Runtime/Scanner/Generators/CompoundCharScannerCharMatchTokenGenerator.cs
@@ -26,7 +26,7 @@ namespace ULox
             case '>':
                 return scanner.EmitTokenSingle(!scanner.Match('=') ? TokenType.GREATER : TokenType.GREATER_EQUAL);
             default:
-                return scanner.SharedNoToken;
+                return Scanner.SharedNoToken;
             }
         }
 

--- a/ulox/ulox.core/Package/Runtime/Scanner/Generators/IdentifierScannerTokenGenerator.cs
+++ b/ulox/ulox.core/Package/Runtime/Scanner/Generators/IdentifierScannerTokenGenerator.cs
@@ -14,9 +14,9 @@ namespace ULox
 
         public void Add(params (string name, TokenType tt)[] toAdd)
         {
-            foreach (var item in toAdd)
+            foreach (var (name, tt) in toAdd)
             {
-                Add(item.name, item.tt);
+                Add(name, tt);
             }
         }
 

--- a/ulox/ulox.core/Package/Runtime/Scanner/Generators/SingleCharScannerCharMatchTokenGenerator.cs
+++ b/ulox/ulox.core/Package/Runtime/Scanner/Generators/SingleCharScannerCharMatchTokenGenerator.cs
@@ -32,7 +32,7 @@ namespace ULox
             case '?':
                 return scanner.EmitTokenSingle(TokenType.QUESTION);
             default:
-                return scanner.SharedNoToken;
+                return Scanner.SharedNoToken;
 
             }
         }

--- a/ulox/ulox.core/Package/Runtime/Scanner/Generators/SlashScannerTokenGenerator.cs
+++ b/ulox/ulox.core/Package/Runtime/Scanner/Generators/SlashScannerTokenGenerator.cs
@@ -7,7 +7,7 @@
             if (scanner.Match('/'))
             {
                 scanner.ReadLine();
-                return scanner.SharedNoToken;
+                return Scanner.SharedNoToken;
             }
             else if (scanner.Match('*'))
             {
@@ -19,7 +19,7 @@
             }
         }
 
-        private Token ConsumeBlockComment(Scanner scanner)
+        private static Token ConsumeBlockComment(Scanner scanner)
         {
             while (!scanner.IsAtEnd())
             {
@@ -32,7 +32,7 @@
                     scanner.Advance();
                 }
             }
-            return scanner.SharedNoToken;
+            return Scanner.SharedNoToken;
         }
         
         public bool DoesMatchChar(char ch)

--- a/ulox/ulox.core/Package/Runtime/Scanner/Generators/WhiteSpaceScannerTokenGenerator.cs
+++ b/ulox/ulox.core/Package/Runtime/Scanner/Generators/WhiteSpaceScannerTokenGenerator.cs
@@ -2,7 +2,7 @@
 {
     public sealed class WhiteSpaceScannerTokenGenerator : IScannerTokenGenerator
     {
-        public Token Consume(Scanner scanner) => scanner.SharedNoToken;
+        public Token Consume(Scanner scanner) => Scanner.SharedNoToken;
 
         public bool DoesMatchChar(char ch)
         {

--- a/ulox/ulox.core/Package/Runtime/Scanner/Scanner.cs
+++ b/ulox/ulox.core/Package/Runtime/Scanner/Scanner.cs
@@ -10,7 +10,7 @@ namespace ULox
         public char CurrentChar => _stringIterator.CurrentChar;
 
         public static readonly Token NoTokenFound = new Token(TokenType.NONE, string.Empty, null, 0, 0);
-        public Token SharedNoToken => NoTokenFound;
+        public static Token SharedNoToken => NoTokenFound;
 
         private readonly List<IScannerTokenGenerator> _scannerGenerators = new List<IScannerTokenGenerator>();
 
@@ -112,7 +112,6 @@ namespace ULox
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Token Next()
         {
-            var lastToken = default(Token);
             while (!IsAtEnd())
             {
                 Advance();

--- a/ulox/ulox.core/Package/Runtime/Types/BoundMethod.cs
+++ b/ulox/ulox.core/Package/Runtime/Types/BoundMethod.cs
@@ -10,7 +10,7 @@
             Method = method;
         }
 
-        public Value Receiver { get; private set; }
-        public ClosureInternal Method { get; private set; }
+        public Value Receiver { get; }
+        public ClosureInternal Method { get; }
     }
 }

--- a/ulox/ulox.core/Package/Runtime/Types/Chunk.cs
+++ b/ulox/ulox.core/Package/Runtime/Types/Chunk.cs
@@ -21,12 +21,12 @@ namespace ULox
         private readonly Dictionary<byte, int> _labelIdToInstruction = new Dictionary<byte, int>();
         private int instructionCount = -1;
 
-        public List<ByteCodePacket> Instructions { get; private set; } = new List<ByteCodePacket>(InstructionStartingCapacity);
-        public List<byte> ArgumentConstantIds { get; private set; } = new List<byte>(50);
+        public List<ByteCodePacket> Instructions { get; } = new List<ByteCodePacket>(InstructionStartingCapacity);
+        public List<byte> ArgumentConstantIds { get; } = new List<byte>(50);
         public IReadOnlyList<Value> Constants => _constants.AsReadOnly();
         public IReadOnlyDictionary<byte, int> Labels => _labelIdToInstruction;
         public string Name { get; set; }
-        public string SourceName { get; private set; }
+        public string SourceName { get; }
         public FunctionType FunctionType { get; internal set; }
         public bool IsLocal => FunctionType == FunctionType.LocalFunction || FunctionType == FunctionType.LocalMethod;
         public bool IsPure => FunctionType == FunctionType.PureFunction;

--- a/ulox/ulox.core/Package/Runtime/Types/CompiledScript.cs
+++ b/ulox/ulox.core/Package/Runtime/Types/CompiledScript.cs
@@ -4,9 +4,9 @@ namespace ULox
 {
     public sealed class CompiledScript
     {
-        public Chunk TopLevelChunk { get; private set; }
-        public int ScriptHash { get; private set; }
-        public List<Chunk> AllChunks { get; private set; }
+        public Chunk TopLevelChunk { get; }
+        public int ScriptHash { get; }
+        public List<Chunk> AllChunks { get; }
 
         public CompiledScript(
             Chunk topLevelChunk,

--- a/ulox/ulox.core/Package/Runtime/Types/Value.cs
+++ b/ulox/ulox.core/Package/Runtime/Types/Value.cs
@@ -17,8 +17,7 @@ namespace ULox
             public override bool Equals(object obj)
             {
                 return obj is TypeNameClass customDummyClass
-                    ? Equals(customDummyClass)
-                    : false;
+                    && Equals(customDummyClass);
             }
 
             public bool Equals(TypeNameClass other)
@@ -209,7 +208,7 @@ namespace ULox
             => !(left == right);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Compare(ref Value lhs, ref Value rhs)
+        public static bool Compare(ref Value lhs, ref Value rhs)
         {
             if (lhs.type != rhs.type)
             {


### PR DESCRIPTION
After rebasing on 4byte opcodes and applying some basic optimisation, we're kinda back at square one, and the changes are pleasing without degrading performance.

close #176 

Also applies a number of Roslynator suggestions