### PR TITLE
Build queue

### DIFF
--- a/ulox-example/Assets/ulox-example/Scripts/SharedEngine.cs
+++ b/ulox-example/Assets/ulox-example/Scripts/SharedEngine.cs
@@ -21,7 +21,7 @@ namespace ULox.Demo
         public void Reset()
         {
             var scriptLocator = new ScriptLocator(null, Application.streamingAssetsPath);
-            Engine = new Engine(new Context(scriptLocator, new Program(), new Vm()));
+            Engine = new Engine(new Context(scriptLocator, new Program(), new Vm(), scriptLocator));
 
             Engine.Context.AddLibrary(new PrintLibrary(x => Debug.Log(x)));
 

--- a/ulox-example/Packages/manifest.json
+++ b/ulox-example/Packages/manifest.json
@@ -3,7 +3,7 @@
     "com.ulox.core": "file:../../ulox/ulox.core/Package",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.ide.visualstudio": "2.0.17",
-    "com.unity.nuget.newtonsoft-json": "3.0.2",
+    "com.unity.nuget.newtonsoft-json": "3.1.0",
     "com.unity.test-framework": "1.1.33",
     "com.unity.testtools.codecoverage": "1.2.2",
     "com.unity.textmeshpro": "3.0.6",

--- a/ulox-example/Packages/packages-lock.json
+++ b/ulox-example/Packages/packages-lock.json
@@ -4,7 +4,9 @@
       "version": "file:../../ulox/ulox.core/Package",
       "depth": 0,
       "source": "local",
-      "dependencies": {}
+      "dependencies": {
+        "com.unity.nuget.newtonsoft-json": "3.0.0"
+      }
     },
     "com.unity.2d.sprite": {
       "version": "1.0.0",
@@ -29,7 +31,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.nuget.newtonsoft-json": {
-      "version": "3.0.2",
+      "version": "3.1.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {},

--- a/ulox-example/ProjectSettings/ProjectVersion.txt
+++ b/ulox-example/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.3.17f1
-m_EditorVersionWithRevision: 2021.3.17f1 (3e8111cac19d)
+m_EditorVersion: 2021.3.23f1
+m_EditorVersionWithRevision: 2021.3.23f1 (213b516bf396)

--- a/ulox/ulox.core.tests/BuildQueueTests.cs
+++ b/ulox/ulox.core.tests/BuildQueueTests.cs
@@ -1,0 +1,47 @@
+﻿using NUnit.Framework;
+
+namespace ULox.Core.Tests
+{
+    [TestFixture]
+    public class BuildQueueTests
+    {
+        [Test]
+        public void ctor_WhenDefault_ShouldNotThrow()
+        {
+            void Act () { new BuildQueue(); }
+
+            Assert.DoesNotThrow(Act);
+        }
+        
+        [Test]
+        public void Enqueue_WhenDefault_ShouldNotThrow()
+        {
+            var queue =  new BuildQueue();
+
+            void Act() { queue.Enqueue(default); }
+
+            Assert.DoesNotThrow(Act);
+        }
+
+        [Test]
+        public void HasItems_WhenEnqueued_ShouldReturnTrue()
+        {
+            var queue = new BuildQueue();
+            queue.Enqueue(default);
+
+            var res = queue.HasItems;
+
+            Assert.IsTrue(res);
+        }
+
+        [Test]
+        public void HasItems_Whenctor_ShouldReturnFalse()
+        {
+            var queue = new BuildQueue();
+
+            var res = queue.HasItems;
+
+            Assert.IsFalse(res);
+        }
+    }
+}

--- a/ulox/ulox.core.tests/ClassTests.cs
+++ b/ulox/ulox.core.tests/ClassTests.cs
@@ -44,6 +44,19 @@ print(t);");
         }
 
         [Test]
+        public void Class_Instance_NoInit()
+        {
+            testEngine.Run(@"
+class T
+{
+}
+
+var t = T(7);");
+
+            StringAssert.StartsWith("Expected zero args for class '<Class T>', as it does not have an 'init' method but got 1 args", testEngine.InterpreterResult);
+        }
+
+        [Test]
         public void Engine_Class_2Var()
         {
             testEngine.Run(@"

--- a/ulox/ulox.core.tests/PlatformEngineTests.cs
+++ b/ulox/ulox.core.tests/PlatformEngineTests.cs
@@ -1,0 +1,20 @@
+﻿using NUnit.Framework;
+
+namespace ULox.Core.Tests
+{
+    public class PlatformEngineTests : EngineTestBase
+    {
+        [Test]
+        public void PlatformFindFiles_Root_NotEmpty()
+        {
+            testEngine.Run(@"
+var res = Platform.FindFiles(""./"",""*.ulox"",true);
+print(res);
+print(res.Count());
+"
+            );
+
+            StringAssert.StartsWith("<inst NativeList>1", testEngine.InterpreterResult);
+        }
+    }
+}

--- a/ulox/ulox.core.tests/PlatformEngineTests.cs
+++ b/ulox/ulox.core.tests/PlatformEngineTests.cs
@@ -7,14 +7,17 @@ namespace ULox.Core.Tests
         [Test]
         public void PlatformFindFiles_Root_NotEmpty()
         {
+            var expectedStart = "<inst NativeList>";
             testEngine.Run(@"
 var res = Platform.FindFiles(""./"",""*.ulox"",true);
 print(res);
 print(res.Count());
 "
             );
-
-            StringAssert.StartsWith("<inst NativeList>1", testEngine.InterpreterResult);
+            
+            StringAssert.StartsWith(expectedStart, testEngine.InterpreterResult);
+            var countPrinted = int.Parse(testEngine.InterpreterResult.Substring(expectedStart.Length));
+            Assert.AreNotEqual(0, countPrinted);
         }
     }
 }

--- a/ulox/ulox.core.tests/PlatformTests.cs
+++ b/ulox/ulox.core.tests/PlatformTests.cs
@@ -1,0 +1,27 @@
+﻿using NUnit.Framework;
+
+namespace ULox.Core.Tests
+{    
+    [TestFixture]
+    public class PlatformTests
+    {
+        [Test]
+        public void ctor_WhenDefault_ShouldNotThrow()
+        {
+            
+            void Act() { new Platform(); }
+
+            Assert.DoesNotThrow(Act);
+        }
+        
+        [Test]
+        public void FindFiles_WhenRootAndAllAndFalse_ShouldReturnNonEmptyArray()
+        {
+            var plat = new Platform();
+
+            var res = plat.FindFiles("./", "*", false);
+
+            Assert.IsTrue(res.Length > 0);
+        }
+    }
+}

--- a/ulox/ulox.core.tests/TableTests.cs
+++ b/ulox/ulox.core.tests/TableTests.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using ULox;
 
 namespace ULox.Core.Tests
 {

--- a/ulox/ulox.core/Package/Runtime/Engine/BuildQueue.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/BuildQueue.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+
+namespace ULox
+{
+    public sealed class BuildQueue
+    {
+        public readonly List<Script> _buildQueue = new List<Script>();
+        private int _cursor;
+
+        public bool HasItems => _buildQueue.Count > 0;
+
+        public void Enqueue(Script script)
+        {
+            _buildQueue.Insert(_cursor,script);
+            _cursor++;
+        }
+
+        public Script Dequeue()
+        {
+            var ret = _buildQueue[0];
+            _buildQueue.RemoveAt(0);
+            _cursor = 0;
+            return ret;
+        }
+    }
+}

--- a/ulox/ulox.core/Package/Runtime/Engine/Context.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/Context.cs
@@ -11,16 +11,20 @@ namespace ULox
         public Context(
             IScriptLocator scriptLocator,
             Program program,
-            Vm vm)
+            Vm vm,
+            IPlatform platform)
         {
             ScriptLocator = scriptLocator;
             Program = program;
             Vm = vm;
+            Platform = platform;
         }
 
         public IScriptLocator ScriptLocator { get; }
         public Program Program { get; }
         public Vm Vm { get; }
+        public IPlatform Platform { get; }
+
         public event Action<string> OnLog;
 
         public void AddLibrary(IULoxLibrary lib)

--- a/ulox/ulox.core/Package/Runtime/Engine/Engine.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/Engine.cs
@@ -39,7 +39,7 @@ namespace ULox
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Engine CreateDefault()
         {
-            var context = new Context(new LocalFileScriptLocator(), new Program(), new Vm());
+            var context = new Context(new LocalFileScriptLocator(), new Program(), new Vm(), new Platform());
             var engine = new Engine(context);
             engine.Context.AddLibrary(new PrintLibrary(x => context.Log(x)));
             return engine;

--- a/ulox/ulox.core/Package/Runtime/Engine/Engine.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/Engine.cs
@@ -1,12 +1,11 @@
-﻿using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 namespace ULox
 {
     public sealed class Engine
     {
         public Context Context { get; }
-        public readonly Queue<Script> _buildQueue = new Queue<Script>();
+        private readonly BuildQueue _buildQueue = new BuildQueue();
 
         public Engine(Context executionContext)
         {
@@ -25,7 +24,7 @@ namespace ULox
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void BuildAndRun()
         {
-            while (_buildQueue.Count > 0)
+            while (_buildQueue.HasItems)
             {
                 var script = _buildQueue.Dequeue();
                 var s = Context.CompileScript(script);

--- a/ulox/ulox.core/Package/Runtime/Engine/Platform.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/Platform.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.IO;
+
+namespace ULox
+{
+    public interface IPlatform
+    {
+        string[] FindFiles(string inDirectory, string withPattern, bool recurse);
+    }
+
+    public sealed class Platform : IPlatform
+    {
+        public string[] FindFiles(string inDirectory, string withPattern, bool recurse)
+        {
+            var searchOption = recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
+            var ret = Array.Empty<string>();
+
+            try
+            {
+                ret = Directory.GetFiles(inDirectory, withPattern, searchOption);
+            }
+            catch (Exception) { }
+
+            return ret;
+        }
+    }
+}

--- a/ulox/ulox.core/Package/Runtime/Engine/ScriptLocator.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/ScriptLocator.cs
@@ -7,7 +7,7 @@ namespace ULox
     public sealed class LocalFileScriptLocator : IScriptLocator
     {
         private readonly DirectoryInfo _directory;
-        
+
         public LocalFileScriptLocator()
         {
             _directory = new DirectoryInfo(Environment.CurrentDirectory);
@@ -19,8 +19,8 @@ namespace ULox
             var externalMatches = Directory.GetFiles(_directory.FullName, $"{name}*");
             if (externalMatches?.Length > 0)
                 return new Script(name, File.ReadAllText(externalMatches[0]));
-            
-            return new Script(name,String.Empty);
+
+            return new Script(name, string.Empty);
         }
     }
 }

--- a/ulox/ulox.core/Package/Runtime/Engine/VM.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/VM.cs
@@ -1381,7 +1381,7 @@ namespace ULox
             }
             else if (argCount != 0)
             {
-                ThrowRuntimeException($"Args given for a class that does not have an 'init' method");
+                ThrowRuntimeException($"Expected zero args for class '{klass}', as it does not have an 'init' method but got {argCount} args");
             }
 
             foreach (var (closure, instruction) in klass.InitChains)

--- a/ulox/ulox.core/Package/Runtime/Library/PlatformStdLibrary.cs
+++ b/ulox/ulox.core/Package/Runtime/Library/PlatformStdLibrary.cs
@@ -1,0 +1,31 @@
+﻿namespace ULox
+{
+    internal static class PlatformStdLibrary
+    {
+        internal static InstanceInternal MakeMathInstance()
+        {
+            var platformLibInst = new InstanceInternal();
+            platformLibInst.AddFieldsToInstance(
+                (nameof(FindFiles), Value.New(FindFiles, 1, 3)));
+
+            platformLibInst.Freeze();
+            return platformLibInst;
+        }
+        
+        public static NativeCallResult FindFiles(Vm vm)
+        {
+            var platform = vm.Engine.Context.Platform;
+            var path = vm.GetArg(1).val.asString.String;
+            var pattern = vm.GetArg(2).val.asString.String;
+            var recurse = vm.GetArg(3).val.asBool;
+            var res = platform.FindFiles(path, pattern, recurse);
+            var arr = NativeListClass.CreateInstance();
+            foreach (var item in res)
+            {
+                arr.List.Add(Value.New(item));
+            }
+            vm.SetNativeReturn(0,Value.New(arr));
+            return NativeCallResult.SuccessfulExpression;
+        }
+    }
+}

--- a/ulox/ulox.core/Package/Runtime/Library/StdLibrary.cs
+++ b/ulox/ulox.core/Package/Runtime/Library/StdLibrary.cs
@@ -21,6 +21,7 @@ namespace ULox
                 ("Assert", Value.New(MakeAssertInstance())),
                 ("Serialise", Value.New(SerialiseStdLibrary.MakeSerialiseInstance())),
                 ("Math", Value.New(MathStdLibrary.MakeMathInstance())),
+                ("Platform", Value.New(PlatformStdLibrary.MakeMathInstance())),
                 (nameof(Duplicate), Value.New(Duplicate, 1, 1)),
                 (nameof(str), Value.New(str, 1, 1)),
                 (nameof(IsFrozen), Value.New(IsFrozen, 1, 1)),


### PR DESCRIPTION
Changes build logic to be depth first style rather than breadth first, which it was previously, mostly by accident. Depth first makes more sense when attempting to build a ulox that is also a build script