### PR TITLE
Data decl flexibility

### DIFF
--- a/ulox/ulox.core.tests/DataTypeTests.cs
+++ b/ulox/ulox.core.tests/DataTypeTests.cs
@@ -110,6 +110,16 @@ data A{a; signs B;}");
         }
 
         [Test]
+        public void Delcared_WhenTrailingCommaInVarList_ShouldCompile()
+        {
+            testEngine.Run(@"
+data Foo {a,b,c,}
+print (Foo);");
+
+            Assert.AreEqual("<Data Foo>", testEngine.InterpreterResult);
+        }
+
+        [Test]
         public void Delcared_WhenTrailingSemiColonInVarList_ShouldCompile()
         {
             testEngine.Run(@"

--- a/ulox/ulox.core.tests/DataTypeTests.cs
+++ b/ulox/ulox.core.tests/DataTypeTests.cs
@@ -108,5 +108,29 @@ data A{a; signs B;}");
 
             StringAssert.StartsWith("Stage out of order. Type 'A' is at stage 'Var' has encountered a late 'Signs' stage element in chunk", testEngine.InterpreterResult);
         }
+
+        [Test]
+        public void Delcared_WhenTrailingSemiColonInVarList_ShouldCompile()
+        {
+            testEngine.Run(@"
+data Foo {a = 1;b = 2;c = 3;}
+print (Foo);
+var f = Foo();
+print(f.a+f.b+f.c);");
+
+            Assert.AreEqual("<Data Foo>6", testEngine.InterpreterResult);
+        }
+
+        [Test]
+        public void Delcared_WhenVarAndSemiColonInVarList_ShouldCompile()
+        {
+            testEngine.Run(@"
+data Foo {a = 1;var b = 2;var c = 3;}
+print (Foo);
+var f = Foo();
+print(f.a+f.b+f.c);");
+
+            Assert.AreEqual("<Data Foo>6", testEngine.InterpreterResult);
+        }
     }
 }

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TypePropertyCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TypePropertyCompilette.cs
@@ -5,12 +5,14 @@
         private TypeCompilette _typeCompilette;
         private TokenType _matchToken;
         private bool _requreEndStatement;
+        private bool _optionalVarKeyword;
 
         public static TypePropertyCompilette CreateForClass()
         {
             var compilette = new TypePropertyCompilette();
             compilette._matchToken = TokenType.VAR;
             compilette._requreEndStatement = true;
+            compilette._optionalVarKeyword = false;
             return compilette;
         }
 
@@ -19,6 +21,7 @@
             var compilette = new TypePropertyCompilette();
             compilette._matchToken = TokenType.NONE;
             compilette._requreEndStatement = false;
+            compilette._optionalVarKeyword = true;
             return compilette;
         }
 
@@ -37,7 +40,10 @@
         {
             do
             {
-                compiler.TokenIterator.Consume(TokenType.IDENTIFIER, "Expect var name.");
+                if (_optionalVarKeyword)
+                    compiler.TokenIterator.Match(TokenType.VAR);
+                
+                compiler.TokenIterator.Consume(TokenType.IDENTIFIER, "Expect var name");
                 byte nameConstant = compiler.AddStringConstant();
                 
                 compiler.NamedVariable(_typeCompilette.CurrentTypeName, false);

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TypePropertyCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TypePropertyCompilette.cs
@@ -82,7 +82,10 @@
 
                 //patch jump from skip imperative
                 compiler.EmitLabel(initFragmentJump);
-            } while (compiler.TokenIterator.Match(TokenType.COMMA));
+
+                //if trailing comma, eat it
+                compiler.TokenIterator.Match(TokenType.COMMA);
+            } while (compiler.TokenIterator.Check(TokenType.IDENTIFIER));
 
             if(_requreEndStatement)
                 compiler.ConsumeEndStatement("property declaration");

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TypeStaticElementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TypeStaticElementCompilette.cs
@@ -20,7 +20,7 @@
         {
             do
             {
-                compiler.TokenIterator.Consume(TokenType.IDENTIFIER, "Expect var name.");
+                compiler.TokenIterator.Consume(TokenType.IDENTIFIER, "Expect var name");
                 byte nameConstant = compiler.AddStringConstant();
 
                 compiler.EmitPacketByte(OpCode.GET_LOCAL, 1);//get class or inst this on the stack


### PR DESCRIPTION
Allow for user to leave trailing commas in data type declares and leave `var` even though it is not required. 

This greatly eases the process of bash it out with dynamics now make a data type for it.

close #200 