### PR TITLE
Change dynamic mid token from ':' to '='

### DIFF
--- a/ulox/ulox.core.tests/ContractTests.cs
+++ b/ulox/ulox.core.tests/ContractTests.cs
@@ -251,11 +251,11 @@ print(res);
         public void Meets_WhenADynamicAndBDynamicMismatch_ShouldReturnFalse()
         {
             testEngine.Run(@"
-var inst = {:};
+var inst = {=};
 fun instMeth(a){}
 inst.Meth = instMeth;
 
-var binst = {:};
+var binst = {=};
 fun binstMeth(){}
 binst.Meth = binstMeth;
 
@@ -271,11 +271,11 @@ print(res);
         public void Meets_WhenADynamicAndBDynamicMatch_ShouldReturnTrue()
         {
             testEngine.Run(@"
-var inst = {:};
+var inst = {=};
 fun instMeth(a){}
 inst.Meth = instMeth;
 
-var binst = {:};
+var binst = {=};
 binst.Meth = instMeth;
 
 
@@ -290,10 +290,10 @@ print(res);
         public void Meets_WhenADynamicAndBDynamicFieldMatch_ShouldReturnTrue()
         {
             testEngine.Run(@"
-var inst = {:};
+var inst = {=};
 inst.a = 3;
 
-var binst = {:};
+var binst = {=};
 binst.a = 7;
 
 var res = inst meets binst;
@@ -307,10 +307,10 @@ print(res);
         public void Meets_WhenADynamicAndBEmptyMatch_ShouldReturnTrue()
         {
             testEngine.Run(@"
-var inst = {:};
+var inst = {=};
 inst.a = 3;
 
-var binst = {:};
+var binst = {=};
 
 var res = inst meets binst;
 print(res);
@@ -323,9 +323,9 @@ print(res);
         public void Meets_WhenAEmptyAndBMismatch_ShouldReturnFalse()
         {
             testEngine.Run(@"
-var inst = {:};
+var inst = {=};
 
-var binst = {:};
+var binst = {=};
 binst.a = 3;
 
 var res = inst meets binst;
@@ -342,7 +342,7 @@ print(res);
 var jsonString = ""{ \""a\"": 1.0,  \""b\"": 2.0,  \""c\"": 3.0 }"";
 var inst = Serialise.FromJson(jsonString);
 
-var binst = {:};
+var binst = {=};
 binst.a = 0;
 binst.b = 0;
 binst.c = 0;
@@ -358,13 +358,13 @@ print(res);
         public void Meets_WhenADeepAndBDeepButMismatch_ShouldReturnFalse()
         {
             testEngine.Run(@"
-var inst = {:};
+var inst = {=};
 inst.a = 1;
-inst.b = {:};
+inst.b = {=};
 
-var binst = {:};
+var binst = {=};
 binst.a = 3;
-binst.b = {:};
+binst.b = {=};
 binst.b.c = 3;
 
 var res = inst meets binst;
@@ -378,14 +378,14 @@ print(res);
         public void Meets_WhenADeepAndBDeepMatch_ShouldReturnTrue()
         {
             testEngine.Run(@"
-var inst = {:};
+var inst = {=};
 inst.a = 1;
-inst.b = {:};
+inst.b = {=};
 inst.b.c = 3;
 
-var binst = {:};
+var binst = {=};
 binst.a = 3;
-binst.b = {:};
+binst.b = {=};
 binst.b.c = 0;
 
 var res = inst meets binst;
@@ -399,9 +399,9 @@ print(res);
         public void Meets_WhenADeepAndBClassMismatch_ShouldReturnTrue()
         {
             testEngine.Run(@"
-var inst = {:};
+var inst = {=};
 inst.a = 1;
-inst.b = {:};
+inst.b = {=};
 inst.b.c = 3;
 
 class B { }
@@ -417,9 +417,9 @@ print(res);
         public void Meets_WhenADeepAndBClassMatch_ShouldReturnTrue()
         {
             testEngine.Run(@"
-var inst = {:};
+var inst = {=};
 inst.a = 1;
-inst.b = {:};
+inst.b = {=};
 inst.b.c = 3;
 
 class B 

--- a/ulox/ulox.core.tests/DynamicTests.cs
+++ b/ulox/ulox.core.tests/DynamicTests.cs
@@ -8,7 +8,7 @@ namespace ULox.Core.Tests
         public void Fields_WhenAddedToDynamic_ShouldSucceed()
         {
             testEngine.Run(@"
-var obj = {:};
+var obj = {=};
 
 obj.a = 1;
 obj.b = 2;
@@ -28,7 +28,7 @@ print(obj.d);
         public void Field_WhenSingleDynamicInline_ShouldSucceed()
         {
             testEngine.Run(@"
-var obj = {a:1,};
+var obj = {a=1,};
 print(obj.a);
 ");
 
@@ -39,7 +39,7 @@ print(obj.a);
         public void Fields_WhenAddedToDynamicInline_ShouldSucceed()
         {
             testEngine.Run(@"
-var obj = {a:1, b:2, c:3, d:-1,};
+var obj = {a=1, b=2, c=3, d=-1,};
 
 var d = obj.a + obj.b + obj.c;
 obj.d = d;
@@ -54,7 +54,7 @@ print(obj.d);
         public void Dynamic_WhenCreated_ShouldPrintInstType()
         {
             testEngine.Run(@"
-var obj = {:};
+var obj = {=};
 
 print(obj);
 ");
@@ -66,7 +66,7 @@ print(obj);
         public void Dynamic_WhenInlineNested_ShouldPrint()
         {
             testEngine.Run(@"
-var obj = {a:1, b:{innerA:2,}, c:3,};
+var obj = {a=1, b={innerA=2,}, c=3,};
 
 print(obj.a);
 print(obj.b);
@@ -84,7 +84,7 @@ print(obj.c);
 var obj = {7};
 ");
 
-            StringAssert.StartsWith("Expect identifier or ':' after '{'", testEngine.InterpreterResult);
+            StringAssert.StartsWith("Expect identifier or '=' after '{'", testEngine.InterpreterResult);
         }
 
         [Test]
@@ -93,7 +93,7 @@ var obj = {7};
             testEngine.Run(@"
 var expected = false;
 var result = 0;
-var obj = {:};
+var obj = {=};
 obj.a = 7;
 readonly obj;
 

--- a/ulox/ulox.core.tests/FunctionAndDelegateTests.cs
+++ b/ulox/ulox.core.tests/FunctionAndDelegateTests.cs
@@ -103,7 +103,7 @@ print(res);
         public void Fun_WhenNamedAndRhsOfAssign_ShouldAssignAndBeGlobal()
         {
             testEngine.Run(@"
-var foo = {:};
+var foo = {=};
 foo.bar = fun Bar(a)
 {
     print(a);
@@ -120,7 +120,7 @@ Bar(2);
         public void Fun_WhenAnonAndRhsOfAssign_ShouldAssignAndNotBeGlobal()
         {
             testEngine.Run(@"
-var foo = {:};
+var foo = {=};
 foo.bar = fun (a)
 {
     print(a);

--- a/ulox/ulox.core.tests/JsonSerialisationTests.cs
+++ b/ulox/ulox.core.tests/JsonSerialisationTests.cs
@@ -106,7 +106,7 @@ obj.a.a = l;";
         [Test]
         public void Serialise_WhenGivenEmptyObject_ShouldReturnExpectedOutput()
         {
-            var scriptString = @"var obj = {:};";
+            var scriptString = @"var obj = {=};";
             var expected = string.Empty;
             var result = "error";
             testEngine.Run(scriptString);

--- a/ulox/ulox.core.tests/LoopingTests.cs
+++ b/ulox/ulox.core.tests/LoopingTests.cs
@@ -646,7 +646,7 @@ loop (arr)
 var arr = [""a"",""b"",""c"",];
 
 var b = 7;
-var someObj = {a:1,c:10,d:{a:1,},};
+var someObj = {a=1,c=10,d={a=1,},};
 
 loop (arr)
 {
@@ -685,7 +685,7 @@ var posList = FromRowCol(outer);
         //        public void Loop_WhenGivenInstanceFieldIdentifier_ShouldPrintItems()
         //        {
         //            testEngine.Run(@"
-        //var thing = {:};
+        //var thing = {=};
         //thing.arr = [""a"",""b"",""c"",];
 
         //loop (thing.arr)

--- a/ulox/ulox.core.tests/MapUsageTests.cs
+++ b/ulox/ulox.core.tests/MapUsageTests.cs
@@ -79,7 +79,7 @@ print(map[""a""]);
         public void Map_WhenInlineCreate_ShouldMatchesValue()
         {
             testEngine.Run(@"
-var map = [""a"":2, ""b"":5, ""c"":{a:1},];
+var map = [""a"":2, ""b"":5, ""c"":{a=1},];
 print(map[""a""]);
 print(map[""b""]);
 print(map[""c""].a);

--- a/ulox/ulox.core.tests/ReadOnlyTests.cs
+++ b/ulox/ulox.core.tests/ReadOnlyTests.cs
@@ -43,7 +43,7 @@ f.a = 2;
         public void Dynamic_ReadOnlyHierarchyThenModifyInner_ShouldError()
         {
             testEngine.Run(@"
-var obj = {a:1, b:{innerA:2,}, c:3,};
+var obj = {a=1, b={innerA=2,}, c=3,};
 
 readonly obj;
 obj.b.innerA = 4;

--- a/ulox/ulox.core.tests/TypeOfTests.cs
+++ b/ulox/ulox.core.tests/TypeOfTests.cs
@@ -74,7 +74,7 @@ print(t);
         public void TypeOf_WhenCalledOnDynamic_ShouldReturnDynamic()
         {
             testEngine.Run(@"
-var t = typeof({:});
+var t = typeof({=});
 print(t);
 ");
 

--- a/ulox/ulox.core.tests/UpdateTests.cs
+++ b/ulox/ulox.core.tests/UpdateTests.cs
@@ -27,7 +27,7 @@ foo = foo update foo2;
 data Foo {}
 
 var foo = Foo();
-var foo2 = {:};
+var foo2 = {=};
 
 foo = foo update foo2;
 "
@@ -89,8 +89,8 @@ print(foo);
         public void Update_WhenPartialMatch_ShouldUpdateValue()
         {
             testEngine.Run(@"
-var foo = {a:1, b:2,};
-var foo2 = {a:2, c:3,};
+var foo = {a=1, b=2,};
+var foo2 = {a=2, c=3,};
 
 foo = foo update foo2;
 print(foo.a);
@@ -108,29 +108,29 @@ print(foo meets foo2);
             testEngine.Run(@"
 var foo = 
 {
-    a:
+    a=
     {
-        val:1
+        val=1
     }, 
-    b:2,
-    d: 
+    b=2,
+    d= 
     {
-        a:1, 
-        b:2,
+        a=1, 
+        b=2,
     }
 };
 
 var foo2 = 
 {
-    a:
+    a=
     {
-        val:2,
-        otherVal:2,
+        val=2,
+        otherVal=2,
     }, 
-    c:3,
-    d: 
+    c=3,
+    d= 
     {
-        a:2, 
+        a=2, 
     }
 };
 
@@ -149,8 +149,8 @@ print(foo meets foo2);
         public void Update_WhenPartialWithNativeCollections_ShouldUpdateValue()
         {
             testEngine.Run(@"
-var foo = {a:[], b:2, d:[1:1, 2:2,]};
-var foo2 = {a:[1,2], c:3, d:[""a"":1, ""b"":2, ""c"":3,]};
+var foo = {a=[], b=2, d=[1:1, 2:2,]};
+var foo2 = {a=[1,2], c=3, d=[""a"":1, ""b"":2, ""c"":3,]};
 
 foo = foo update foo2;
 print(foo.a.Count());

--- a/ulox/ulox.core.tests/uloxs/Samples/11-Dynamic.ulox
+++ b/ulox/ulox.core.tests/uloxs/Samples/11-Dynamic.ulox
@@ -1,7 +1,7 @@
 // while all objects can do this, using Dynamic makes your intent clear
 //  and protects you from any future changes around
 
-var obj = {:};
+var obj = {=};
 
 obj.a = 1;
 obj.b = 2;
@@ -20,5 +20,5 @@ obj.Meth = Method;
 print(obj.Meth(obj));
 
 // dynamic objects can also be made inline
-var obj2 = {a:1, b:2, c:3, d:-1, val:"expected", Meth:Method};
+var obj2 = {a=1, b=2, c=3, d=-1, val="expected", Meth=Method};
 obj2.d = obj2.a + obj2.b + obj2.c;

--- a/ulox/ulox.core.tests/uloxs/Samples/15-Freeze.ulox
+++ b/ulox/ulox.core.tests/uloxs/Samples/15-Freeze.ulox
@@ -7,7 +7,7 @@ class Foo
 
 var inst = Foo();
 
-var dynInst = {:};
+var dynInst = {=};
 
 print(IsFrozen(Foo));
 print(IsFrozen(inst));

--- a/ulox/ulox.core.tests/uloxs/Samples/24-Update.ulox
+++ b/ulox/ulox.core.tests/uloxs/Samples/24-Update.ulox
@@ -6,16 +6,16 @@ var res;
 
 var lhs = 
 {
-    a: 1,
-    b: 2,
-    c: 3
+    a= 1,
+    b= 2,
+    c= 3
 };
 
 var rhs = 
 {
-    a: 4,
-    b: 5,
-    c: 6,
+    a= 4,
+    b= 5,
+    c= 6,
 };
 
 res = lhs update rhs;
@@ -26,10 +26,10 @@ res = lhs update rhs;
 
 var bigRhs =
 {
-    a: 7,
-    b: 8,
-    c: 9,
-    d: 10,
+    a= 7,
+    b= 8,
+    c= 9,
+    d= 10,
 };
 
 // res now contains the same as lhs, and lhs still does not have a 'd' field
@@ -39,7 +39,7 @@ res = lhs update bigRhs;
 
 var smallRhs =
 {
-    a: 11,
+    a= 11,
 };
 
 // res now contains the same as lhs, and a is 11, b is still 8, c is still 9
@@ -49,9 +49,9 @@ res = lhs update smallRhs;
 
 var typeMismatch =
 {
-    a: "string",
-    b: 2,
-    c: 3,
+    a= "string",
+    b= 2,
+    c= 3,
 };
 
 res = lhs update typeMismatch;
@@ -61,27 +61,27 @@ res = lhs update typeMismatch;
 
 var nestedLhs =
 {
-    a: 1,
-    b: 2,
-    c: 3,
-    d: 
+    a= 1,
+    b= 2,
+    c= 3,
+    d= 
     {
-        e: 4,
-        f: 5,
-        g: 6,
+        e= 4,
+        f= 5,
+        g= 6,
     },
 };
 
 var nestedRhs =
 {
-    a: 7,
-    b: 8,
-    c: 9,
-    d: 
+    a= 7,
+    b= 8,
+    c= 9,
+    d= 
     {
-        e: 10,
-        f: 11,
-        g: 12,
+        e= 10,
+        f= 11,
+        g= 12,
     },
 };
 
@@ -91,21 +91,21 @@ res = nestedLhs update nestedRhs;
 
 var colLhs =
 {
-    a: 1,
-    b: ["key":"val"],
-    c: 3,
-    d: [4, 5, 6],
+    a= 1,
+    b= ["key":"val"],
+    c= 3,
+    d= [4, 5, 6],
 };
 
 var colrhs = 
 {
-    a: 7,
-    b: 
+    a= 7,
+    b= 
     [
         "otherkey":" val2",
-        "otherOtherKey": "val3",
+        "otherOtherKey":"val3",
     ],
-    d: [10, 11, 12, 13, 14, 15],
+    d= [10, 11, 12, 13, 14, 15],
 };
 
 res = colLhs update colrhs;

--- a/ulox/ulox.core.tests/uloxs/Tests/ConfirmVmExceptions.ulox
+++ b/ulox/ulox.core.tests/uloxs/Tests/ConfirmVmExceptions.ulox
@@ -26,7 +26,7 @@ testset ConfirmVmExceptions
     {
         fun InvalidInvoke()
         {
-            var a = {:};
+            var a = {=};
             a.Invoke();
         }
 
@@ -58,8 +58,8 @@ testset ConfirmVmExceptions
     {
         fun InvalidMathOp()
         {
-            var a = {:};
-            var b = {:};
+            var a = {=};
+            var b = {=};
             a += b;
         }
 
@@ -70,8 +70,8 @@ testset ConfirmVmExceptions
     {
         fun InvalidCompare()
         {
-            var a = {:};
-            var b = {:};
+            var a = {=};
+            var b = {=};
             var res = a < b;
         }
 

--- a/ulox/ulox.core.tests/uloxs/Tests/ContractMeets.ulox
+++ b/ulox/ulox.core.tests/uloxs/Tests/ContractMeets.ulox
@@ -80,9 +80,9 @@ testset ContractMeetsTests
     test DynMeetsDyn_SameFieldButDifferentType_False
     {
         var res = null;
-        var a = {:};
+        var a = {=};
         a.a = 3;
-        var b = {:};
+        var b = {=};
         b.a = "3";
 
         res = a meets b;

--- a/ulox/ulox.core.tests/uloxs/Tests/Dynamic.ulox
+++ b/ulox/ulox.core.tests/uloxs/Tests/Dynamic.ulox
@@ -4,7 +4,7 @@ testset DynamicTests
     {
         var expected = 3;
         var result = 0;
-        var o = {:};
+        var o = {=};
         o.val = expected;
 
         result = o.val;
@@ -16,7 +16,7 @@ testset DynamicTests
     {
         var expected = 3;
         var result = 0;
-        var o = {:};
+        var o = {=};
         fun Method(){retval =expected;}
         o.Meth = Method;
 
@@ -29,7 +29,7 @@ testset DynamicTests
     {
         var expected = 3;
         var result = 0;
-        var o = {val:expected, Meth: fun (self) {retval =self.val;},};
+        var o = {val=expected, Meth= fun (self) {retval =self.val;},};
        
         result = o.Meth(o);
 
@@ -40,7 +40,7 @@ testset DynamicTests
     {
         var expected = 3;
         var result = 0;
-        var o = {val:expected, Meth: fun (self) {retval =self.val;},};
+        var o = {val=expected, Meth= fun (self) {retval =self.val;},};
        
         result = o.Meth(o);
 
@@ -52,7 +52,7 @@ testset DynamicTests
         fun Act()
         {
             var s = "hello";
-            var dyn = {:};
+            var dyn = {=};
             dyn.HasField(s, "afield");
         }
 
@@ -64,7 +64,7 @@ testset DynamicTests
         fun Act()
         {
             var s = "hello";
-            var dyn = {:};
+            var dyn = {=};
             dyn.RemoveField(s, "afield");
         }
 

--- a/ulox/ulox.core.tests/uloxs/Tests/DynamicOpOverload.ulox
+++ b/ulox/ulox.core.tests/uloxs/Tests/DynamicOpOverload.ulox
@@ -1,6 +1,6 @@
 fun MakeVec2(x,y)
 {
-    var res = {:};
+    var res = {=};
 
     fun _add(lhs,rhs)
     {

--- a/ulox/ulox.core.tests/uloxs/Tests/NativeClasses.ulox
+++ b/ulox/ulox.core.tests/uloxs/Tests/NativeClasses.ulox
@@ -76,7 +76,7 @@ testset NativeClassesLibraryTests
         var expected = 6;
         var result = 0;
 
-        var obj = {:};
+        var obj = {=};
         obj.a = 1;
         obj.b = 2;
         obj.c = 3;
@@ -97,7 +97,7 @@ testset DynamicLibraryTests
         var expectedB = false;
         var resultA = false;
         var resultB = true;
-        var obj = {:};
+        var obj = {=};
         obj.a = 7;
 
         resultA = obj.HasField(obj, "a");
@@ -111,7 +111,7 @@ testset DynamicLibraryTests
     {
         var expected = false;
         var result = 0;
-        var obj = {:};
+        var obj = {=};
         obj.a = 7;
 
         obj.RemoveField(obj, "a");

--- a/ulox/ulox.core.tests/uloxs/Tests/SerialiseLibrary.ulox
+++ b/ulox/ulox.core.tests/uloxs/Tests/SerialiseLibrary.ulox
@@ -2,7 +2,7 @@ testset SerialiseLibraryTests
 {
     test ToEmpty
     {
-        var obj = {:};
+        var obj = {=};
         var expected = "";
         var res = "ERROR";
         
@@ -13,7 +13,7 @@ testset SerialiseLibraryTests
 
     test SimpleTo
     {
-        var obj = {:};
+        var obj = {=};
         obj.a = 1;
         obj.b = 2;
         obj.c = 3;
@@ -32,7 +32,7 @@ testset SerialiseLibraryTests
     test SimpleFrom
     {
         var jsonString = "{ \"a\": 1.0,  \"b\": 2.0,  \"c\": 3.0 }";
-        var res = {:};
+        var res = {=};
         
         res = Serialise.FromJson(jsonString);
 
@@ -43,8 +43,8 @@ testset SerialiseLibraryTests
 
     test ComplexTo
     {
-        var obj = {:};
-        obj.a = {:};
+        var obj = {=};
+        obj.a = {=};
         obj.a.b = 1;
         obj.a.c = 2;
         obj.a.d = 3;
@@ -91,7 +91,7 @@ testset SerialiseLibraryTests
     \"c\"
   ]
 }";
-        var res = {:};
+        var res = {=};
         
         res = Serialise.FromJson(jsonString);
 

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compiler.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compiler.cs
@@ -694,7 +694,8 @@ namespace ULox
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void BraceCreateDynamic(Compiler compiler, bool arg2)
         {
-            if (compiler.TokenIterator.Match(TokenType.COLON)
+            var midTok = TokenType.ASSIGN;
+            if (compiler.TokenIterator.Match(midTok)
                   && compiler.TokenIterator.Match(TokenType.CLOSE_BRACE))
             {
                 compiler.EmitPacket(new ByteCodePacket(OpCode.NATIVE_TYPE, NativeType.Dynamic));
@@ -711,7 +712,7 @@ namespace ULox
                     //add the constant
                     var identConstantID = compiler.AddStringConstant();
                     //read the colon
-                    compiler.TokenIterator.Consume(TokenType.COLON, "Expect ':' after identifiier.");
+                    compiler.TokenIterator.Consume(midTok, "Expect '=' after identifiier.");
                     //do expression
                     compiler.Expression();
                     //we need a set property
@@ -724,7 +725,7 @@ namespace ULox
             }
             else
             {
-                compiler.ThrowCompilerException("Expect identifier or ':' after '{'");
+                compiler.ThrowCompilerException("Expect identifier or '=' after '{'");
             }
         }
 


### PR DESCRIPTION
Previously using : made sense in terms of matching other language and ddls, but for moving from prototyping code using dynmics to classes/data types, using = means there is far less syntax chores.