### PR TITLE
Additional std lib methods

### DIFF
--- a/ulox/ulox.core.tests/ByteCodeInterpreterTestEngine.cs
+++ b/ulox/ulox.core.tests/ByteCodeInterpreterTestEngine.cs
@@ -48,6 +48,7 @@ namespace ULox.Core.Tests
                 _logger(MyEngine.Context.Program.Disassembly);
                 _logger(VmUtil.GenerateGlobalsDump(MyEngine.Context.Vm));
                 _logger(VmUtil.GenerateValueStackDump(MyEngine.Context.Vm));
+                _logger(VmUtil.GenerateReturnDump(MyEngine.Context.Vm));
             }
         }
 

--- a/ulox/ulox.core.tests/FastListTests.cs
+++ b/ulox/ulox.core.tests/FastListTests.cs
@@ -1,0 +1,100 @@
+﻿using NUnit.Framework;
+
+namespace ULox.Core.Tests
+{
+    [TestFixture]
+    public class FastListTests
+    {
+        [Test]
+        public void Count_WhenEmpty_ShouldHave0()
+        {
+            var fastList = new FastList<object>();
+
+            Assert.AreEqual(0, fastList.Count);
+        }
+
+        [Test]
+        public void Add_WhenCalledOnEmpty_ShouldHave1Count()
+        {
+            var fastList = new FastList<object>();
+
+            fastList.Add(new object());
+
+            Assert.AreEqual(1, fastList.Count);
+        }
+
+        [Test]
+        public void RemoveAt_WhenCalledOnOneElement_ShouldHave0Count()
+        {
+            var fastList = new FastList<object>();
+            fastList.Add(new object());
+
+            fastList.RemoveAt(0);
+
+            Assert.AreEqual(0, fastList.Count);
+        }
+
+        [Test]
+        public void Remove_WhenHasElement_ShouldHave0Count()
+        {
+            var fastList = new FastList<object>();
+            var obj = new object();
+            fastList.Add(obj);
+
+            fastList.Remove(obj);
+
+            Assert.AreEqual(0, fastList.Count);
+        }
+
+        [Test]
+        public void Clear_WhenCalledOnOneElement_ShouldHave0Count()
+        {
+            var fastList = new FastList<object>();
+            fastList.Add(new object());
+
+            fastList.Clear();
+
+            Assert.AreEqual(0, fastList.Count);
+        }
+
+        [Test]
+        public void Indexer_WhenCalledOnOneElement_ShouldReturnElement()
+        {
+            var fastList = new FastList<object>();
+            var obj = new object();
+            fastList.Add(obj);
+
+            var result = fastList[0];
+
+            Assert.AreEqual(obj, result);
+        }
+
+        [Test]
+        public void Indexer_WhenCalledOnOneElement_ShouldSetElement()
+        {
+            var fastList = new FastList<object>();
+            var obj = new object();
+            fastList.Add(obj);
+
+            fastList[0] = new object();
+
+            Assert.AreNotEqual(obj, fastList[0]);
+        }
+
+        [Test]
+        public void GetEnumerator_WhenTwoElements_ShouldPrintBoth()
+        {
+            var fastList = new FastList<object>();
+            fastList.Add(1);
+            fastList.Add(2);
+            var res = "";
+
+            foreach (var item in fastList)
+            {
+                res += item.ToString();
+            }
+
+            StringAssert.AreEqualIgnoringCase("12", res);
+        }
+    }
+}

--- a/ulox/ulox.core.tests/FastListTests.cs
+++ b/ulox/ulox.core.tests/FastListTests.cs
@@ -47,6 +47,18 @@ namespace ULox.Core.Tests
         }
 
         [Test]
+        public void Remove_WhenDoesNotHaveElement_ShouldHave1Count()
+        {
+            var fastList = new FastList<object>();
+            fastList.Add(new object());
+
+            var res = fastList.Remove(new object());
+
+            Assert.AreEqual(1, fastList.Count);
+            Assert.IsFalse(res);
+        }
+
+        [Test]
         public void Clear_WhenCalledOnOneElement_ShouldHave0Count()
         {
             var fastList = new FastList<object>();
@@ -95,6 +107,28 @@ namespace ULox.Core.Tests
             }
 
             StringAssert.AreEqualIgnoringCase("12", res);
+        }
+
+        [Test]
+        public void EnsureCapacity_WhenLess_ShouldHaveSame()
+        {
+            var fastList = new FastList<object>();
+            var initialCap = fastList.Capacity;
+
+            fastList.EnsureCapacity(1);
+
+            Assert.AreEqual(initialCap, fastList.Capacity);
+        }
+
+        [Test]
+        public void EnsureCapacity_WhenMore_ShouldNotHaveSame()
+        {
+            var fastList = new FastList<object>();
+            var initialCap = fastList.Capacity;
+
+            fastList.EnsureCapacity(100);
+
+            Assert.AreNotEqual(initialCap, fastList.Capacity);
         }
     }
 }

--- a/ulox/ulox.core.tests/ListUsageTests.cs
+++ b/ulox/ulox.core.tests/ListUsageTests.cs
@@ -335,5 +335,17 @@ print(list.Reduce(accum));
 
             Assert.AreEqual("23", testEngine.InterpreterResult);
         }
+
+        [Test]
+        public void Clear_When3LitteralItems_ShouldBeCount0()
+        {
+            testEngine.Run(@"
+var arr = [1,2,3];
+arr.Clear();
+print(arr.Count());
+");
+
+            Assert.AreEqual("0", testEngine.InterpreterResult);
+        }
     }
 }

--- a/ulox/ulox.core.tests/ListUsageTests.cs
+++ b/ulox/ulox.core.tests/ListUsageTests.cs
@@ -347,5 +347,27 @@ print(arr.Count());
 
             Assert.AreEqual("0", testEngine.InterpreterResult);
         }
+
+        [Test]
+        public void Front_When3LitteralItems_ShouldBe1()
+        {
+            testEngine.Run(@"
+var arr = [1,2,3];
+print(arr.Front());
+");
+
+            Assert.AreEqual("1", testEngine.InterpreterResult);
+        }
+
+        [Test]
+        public void Back_When3LitteralItems_ShouldBe3()
+        {
+            testEngine.Run(@"
+var arr = [1,2,3];
+print(arr.Back());
+");
+
+            Assert.AreEqual("3", testEngine.InterpreterResult);
+        }
     }
 }

--- a/ulox/ulox.core.tests/MathTests.cs
+++ b/ulox/ulox.core.tests/MathTests.cs
@@ -184,5 +184,82 @@ expect res == 6;
 
             Assert.AreEqual("", testEngine.InterpreterResult);
         }
+
+        [Test]
+        public void Round_WhenLower_ShouldBeFloor()
+        {
+            testEngine.Run(@"
+var res = Math.Round(5.4);
+expect res == 5;
+");
+
+            Assert.AreEqual("", testEngine.InterpreterResult);
+        }
+
+        [Test]
+        public void Round_WhenUpper_ShouldBeCeil()
+        {
+            testEngine.Run(@"
+var res = Math.Round(5.6);
+expect res == 6;
+");
+
+            Assert.AreEqual("", testEngine.InterpreterResult);
+        }
+
+        [Test]
+        public void Sign_WhenPositive_Should1()
+        {
+            testEngine.Run(@"
+var res = Math.Sign(1);
+expect res == 1;
+");
+
+            Assert.AreEqual("", testEngine.InterpreterResult);
+        }
+
+        [Test]
+        public void Sign_WhenNegative_ShouldMinus1()
+        {
+            testEngine.Run(@"
+var res = Math.Sign(-1);
+expect res == -1;
+");
+
+            Assert.AreEqual("", testEngine.InterpreterResult);
+        }
+
+        [Test]
+        public void Max_When1And2_ShouldBe2()
+        {
+            testEngine.Run(@"
+var res = Math.Max(1,2);
+expect res == 2;
+");
+
+            Assert.AreEqual("", testEngine.InterpreterResult);
+        }
+
+        [Test]
+        public void Min_When1And2_ShouldBe1()
+        {
+            testEngine.Run(@"
+var res = Math.Min(1,2);
+expect res == 1;
+");
+
+            Assert.AreEqual("", testEngine.InterpreterResult);
+        }
+
+        [Test]
+        public void Clamp_When0And1And2_ShouldBe1()
+        {
+            testEngine.Run(@"
+var res = Math.Clamp(0,1,2);
+expect res == 1;
+");
+
+            Assert.AreEqual("", testEngine.InterpreterResult);
+        }
     }
 }

--- a/ulox/ulox.core.tests/NativeCallTests.cs
+++ b/ulox/ulox.core.tests/NativeCallTests.cs
@@ -165,5 +165,25 @@ Locals();");
 
             Assert.AreEqual("4", testEngine.InterpreterResult);
         }
+
+        [Test]
+        public void Run_WhenNativeFuncWithMultipleArgs_ShouldReceiveAllInOrder()
+        {
+            NativeCallResult Func(Vm vm)
+            {
+                var index = 0;
+                var a = vm.GetNextArg(ref index).val.asString;
+                var b = vm.GetNextArg(ref index).val.asString;
+                var c = vm.GetNextArg(ref index).val.asString;
+                vm.SetNativeReturn(0, Value.New($"Hello, {a}, {b}, and {c}, I'm native."));
+                return NativeCallResult.SuccessfulExpression;
+            }
+
+            testEngine.MyEngine.Context.Vm.Globals.AddOrSet(new HashedString("Meth"), Value.New(Func, 1, 3));
+
+            testEngine.Run(@"print (Meth(""you"", ""me"", ""everybody""));");
+
+            Assert.AreEqual("Hello, you, me, and everybody, I'm native.", testEngine.InterpreterResult);
+        }
     }
 }

--- a/ulox/ulox.core.tests/ScannerTests.cs
+++ b/ulox/ulox.core.tests/ScannerTests.cs
@@ -1,7 +1,6 @@
 ﻿using NUnit.Framework;
 using System.Collections.Generic;
 using System.Linq;
-using ULox;
 
 namespace ULox.Core.Tests
 {

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compiler.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compiler.cs
@@ -197,7 +197,7 @@ namespace ULox
             var comp = CurrentCompilerState;
             for (int i = comp.localCount - 1; i >= 0; i--)
             {
-                if (comp.locals[i].Depth < depth)
+                if (comp.locals[i].Depth <= depth)
                     break;
 
                 if (!comp.locals[i].IsCaptured)

--- a/ulox/ulox.core/Package/Runtime/Engine/VM.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/VM.cs
@@ -53,6 +53,9 @@ namespace ULox
         public Value GetArg(int index)
             => _valueStack[_currentCallFrame.StackStart + index];
 
+        public Value GetNextArg(ref int index)
+            => _valueStack[_currentCallFrame.StackStart + (++index)];
+
         public int CurrentFrameStackValues => _valueStack.Count - _currentCallFrame.StackStart;
         public Value StackTop => _valueStack.Peek();
         public int StackCount => _valueStack.Count;

--- a/ulox/ulox.core/Package/Runtime/Library/Classes/NativeListClass.cs
+++ b/ulox/ulox.core/Package/Runtime/Library/Classes/NativeListClass.cs
@@ -41,7 +41,7 @@ namespace ULox
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static List<Value> GetArg0NativeListInstance(Vm vm)
+        private static FastList<Value> GetArg0NativeListInstance(Vm vm)
         {
             var inst = vm.GetArg(0);
             var nativeListinst = inst.val.asInstance as NativeListInstance;
@@ -140,7 +140,7 @@ namespace ULox
             var retval = MakeInstance();
             var retvalList = ((NativeListInstance)retval).List;
 
-            retvalList.Capacity = list.Count;
+            retvalList.EnsureCapacity(list.Count);
 
             for (int i = 0; i < list.Count; i++)
             {
@@ -205,7 +205,7 @@ namespace ULox
             var retval = MakeInstance();
             var retvalList = ((NativeListInstance)retval).List;
 
-            retvalList.Capacity = list.Count;
+            retvalList.EnsureCapacity(list.Count);
 
             for (int i = 0; i < list.Count; i++)
             {
@@ -250,7 +250,7 @@ namespace ULox
 
             var retval = MakeInstance();
             var retvalList = ((NativeListInstance)retval).List;
-            retvalList.Capacity = list.Count;
+            retvalList.EnsureCapacity(list.Count);
 
             for (int i = 0; i < orderByArr.Length; i++)
             {
@@ -327,7 +327,7 @@ namespace ULox
             var retval = MakeInstance();
             var retvalList = ((NativeListInstance)retval).List;
 
-            retvalList.Capacity = list.Count;
+            retvalList.EnsureCapacity(list.Count);
 
             for (int i = 0; i < list.Count; i++)
             {

--- a/ulox/ulox.core/Package/Runtime/Library/Classes/NativeListClass.cs
+++ b/ulox/ulox.core/Package/Runtime/Library/Classes/NativeListClass.cs
@@ -35,7 +35,8 @@ namespace ULox
                 (nameof(Until), Value.New(Until, 1, 1)),
                 
                 (nameof(Grow), Value.New(Grow, 1, 2)),
-                (nameof(Shrink), Value.New(Shrink, 1, 1))
+                (nameof(Shrink), Value.New(Shrink, 1, 1)),
+                (nameof(Clear), Value.New(Clear, 1, 0))
                                   );
         }
 
@@ -367,6 +368,14 @@ namespace ULox
                 }
             }
 
+            return NativeCallResult.SuccessfulExpression;
+        }
+
+        private NativeCallResult Clear(Vm vm)
+        {
+            var list = GetArg0NativeListInstance(vm);
+            vm.SetNativeReturn(0, Value.New(list.Count));
+            list.Clear();
             return NativeCallResult.SuccessfulExpression;
         }
     }

--- a/ulox/ulox.core/Package/Runtime/Library/Classes/NativeListClass.cs
+++ b/ulox/ulox.core/Package/Runtime/Library/Classes/NativeListClass.cs
@@ -36,7 +36,10 @@ namespace ULox
                 
                 (nameof(Grow), Value.New(Grow, 1, 2)),
                 (nameof(Shrink), Value.New(Shrink, 1, 1)),
-                (nameof(Clear), Value.New(Clear, 1, 0))
+                (nameof(Clear), Value.New(Clear, 1, 0)),
+
+                (nameof(Front), Value.New(Front, 1, 0)),
+                (nameof(Back), Value.New(Back, 1, 0))
                                   );
         }
 
@@ -376,6 +379,20 @@ namespace ULox
             var list = GetArg0NativeListInstance(vm);
             vm.SetNativeReturn(0, Value.New(list.Count));
             list.Clear();
+            return NativeCallResult.SuccessfulExpression;
+        }
+
+        private NativeCallResult Front(Vm vm)
+        {
+            var list = GetArg0NativeListInstance(vm);
+            vm.SetNativeReturn(0, list.Count > 0 ? list[0] : Value.Null());
+            return NativeCallResult.SuccessfulExpression;
+        }
+
+        private NativeCallResult Back(Vm vm)
+        {
+            var list = GetArg0NativeListInstance(vm);
+            vm.SetNativeReturn(0, list.Count > 0 ? list[list.Count - 1] : Value.Null());
             return NativeCallResult.SuccessfulExpression;
         }
     }

--- a/ulox/ulox.core/Package/Runtime/Library/Classes/NativeListInstance.cs
+++ b/ulox/ulox.core/Package/Runtime/Library/Classes/NativeListInstance.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 namespace ULox
 {
@@ -11,7 +10,7 @@ namespace ULox
         {
         }
 
-        public List<Value> List { get; } = new List<Value>();
+        public FastList<Value> List { get; } = new FastList<Value>();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Set(Value ind, Value val)

--- a/ulox/ulox.core/Package/Runtime/Library/MathStdLibrary.cs
+++ b/ulox/ulox.core/Package/Runtime/Library/MathStdLibrary.cs
@@ -33,7 +33,8 @@ namespace ULox
                 (nameof(Sqrt), Value.New(Sqrt, 1, 1)),
                 (nameof(Tan), Value.New(Tan, 1, 1)),
                 (nameof(Max), Value.New(Max, 1, 2)),
-                (nameof(Min), Value.New(Min, 1, 2))
+                (nameof(Min), Value.New(Min, 1, 2)),
+                (nameof(Clamp), Value.New(Clamp, 1, 3))
                 );
 
             diLibInst.Freeze();
@@ -227,6 +228,16 @@ namespace ULox
             var arg1 = vm.GetArg(1);
             var arg2 = vm.GetArg(2);
             var result = Math.Min(arg1.val.asDouble, arg2.val.asDouble);
+            vm.SetNativeReturn(0, Value.New(result));
+            return NativeCallResult.SuccessfulExpression;
+        }
+
+        private static NativeCallResult Clamp(Vm vm)
+        {
+            var arg1 = vm.GetArg(1);
+            var arg2 = vm.GetArg(2);
+            var arg3 = vm.GetArg(3);
+            var result = Math.Min(Math.Max(arg1.val.asDouble, arg2.val.asDouble), arg3.val.asDouble);
             vm.SetNativeReturn(0, Value.New(result));
             return NativeCallResult.SuccessfulExpression;
         }

--- a/ulox/ulox.core/Package/Runtime/Types/FastList.cs
+++ b/ulox/ulox.core/Package/Runtime/Types/FastList.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace ULox
+{
+    public sealed class FastList<T> : IEnumerable<T>
+    {
+        public const int StartingSize = 32;
+        public const int GrowFactor = 2;
+        private T[] _array = new T[StartingSize];
+        private int _back = -1;
+
+        public FastList()
+        { }
+
+        public int Count => _back + 1;
+
+
+        public T this[int index]
+        {
+            get => _array[index];
+            set => _array[index] = value;
+        }
+
+        public void Add(T val)
+        {
+            if (_back >= _array.Length - 2)
+                System.Array.Resize(ref _array, _array.Length * GrowFactor);
+            _array[++_back] = val;
+        }
+
+        public void RemoveAt(int index)
+        {
+            var count = Count;
+            for (int i = index; i < count; i++)
+                _array[i] = _array[i + 1];
+            _back--;
+        }
+
+        public void Clear()
+        {
+            _back = -1;
+        }
+
+        public bool Remove(T item)
+        {
+            var count = Count;
+            for (int i = 0; i < count; i++)
+            {
+                if (_array[i].Equals(item))
+                {
+                    RemoveAt(i);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            for (int i = 0; i < _back+1; i++)
+                yield return _array[i];
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            for (int i = 0; i < _back+1; i++)
+                yield return _array[i];
+        }
+
+        public void EnsureCapacity(int capacity)
+        {
+            if (_array.Length < capacity)
+                System.Array.Resize(ref _array, capacity);
+        }
+    }
+}

--- a/ulox/ulox.core/Package/Runtime/Types/FastList.cs
+++ b/ulox/ulox.core/Package/Runtime/Types/FastList.cs
@@ -15,6 +15,8 @@ namespace ULox
 
         public int Count => _back + 1;
 
+        public int Capacity => _array.Length;
+
 
         public T this[int index]
         {


### PR DESCRIPTION
Math: Clamp
List: Clear, Front, Back

List internally now uses our own class, not any faster right now but allows us to tweak trade offs

Corrects a missing <= for stack depth check in compiler

Remember to Add/Update the:
- [x] Sample scripts
- [x] Test scripts
