### PR TITLE
Merge frozen-init into main: Simplify MakeInstance vm logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ var
 var anAddress = Address();
 anAddress.number = 7;
 
-//classes are the most feature rich.
+//classes are the feature rich.
 //  The order of elements declared within the class is enforced
 class MyFoo
 {

--- a/ulox/ulox.core.bench/BenchmarkScripts.cs
+++ b/ulox/ulox.core.bench/BenchmarkScripts.cs
@@ -75,15 +75,13 @@ fun RandVec2() (x,y)
 
 class Ball
 {
-	init()
-	{
-		var (x,y) = RandVec2();
-		this.posx = x;
-		this.posy = y;
+	var posx = 0;
+    var posy = 0;
+    var velx = 0;
+    var vely = 0;
 
-		var (vx,vy) = RandVec2();
-		this.velx = vx;
-		this.vely = vy;
+	init(posx, posy, velx, vely)
+	{
 	}
 }
 
@@ -93,7 +91,9 @@ fun SetupGame()
 
 	for(var i = 0; i < numBallsToSpawn; i += 1)
 	{
-		balls.Add(Ball());
+		var (x,y) = RandVec2();
+		var (vx,vy) = RandVec2();
+		balls.Add(Ball(x,y,vx,vy));
 	}
 	print(balls.Count());
 }
@@ -106,7 +106,6 @@ fun Update()
 
 	loop balls
 	{
-		//print(GenerateStackDump());
   		item.posx = item.posx + item.velx * dt;
   		item.posy = item.posy + item.vely * dt;
 

--- a/ulox/ulox.core.tests/ClassTests.cs
+++ b/ulox/ulox.core.tests/ClassTests.cs
@@ -276,9 +276,8 @@ var t = T(1,2);");
         {
             testEngine.Run(@"
 class CoffeeMaker {
-    init(_coffee) {
-        this.coffee = _coffee;
-    }
+    var coffee; 
+    init(coffee) {}
 
     brew() {
         print (""Enjoy your cup of "" + this.coffee);
@@ -300,9 +299,8 @@ delegate();");
         {
             testEngine.Run(@"
 class CoffeeMaker {
-    init(_coffee) {
-        this.coffee = _coffee;
-    }
+    var coffee; 
+    init(coffee) {}
 
     brew() {
         print (""Enjoy your cup of "" + this.coffee);
@@ -331,9 +329,8 @@ delegate();");
         {
             testEngine.Run(@"
 class CoffeeMaker {
-    init(_coffee) {
-        this.coffee = _coffee;
-    }
+    var coffee; 
+    init(coffee) {}
 
     brew(method) {
         print (""Enjoy your cup of "" + this.coffee + "" ("" + method  + "")"");
@@ -357,9 +354,8 @@ delegate(""V60"");");
         {
             testEngine.Run(@"
 class CoffeeMaker {
-    init(_coffee) {
-        this.coffee = _coffee;
-    }
+    var coffee; 
+    init(coffee) {}
 
     brew() {
         print (""Enjoy your cup of "" + this.coffee);
@@ -387,9 +383,8 @@ delegate();");
         {
             testEngine.Run(@"
 class CoffeeMaker {
-    init(_coffee) {
-        this.coffee = _coffee;
-    }
+    var coffee; 
+    init(coffee) {}
 
     brew() {
         print (""Enjoy your cup of "" + this.coffee);
@@ -427,9 +422,8 @@ runner.RunIt(delegate);");
             testEngine.Run(@"
 class CoffeeMaker {
 var brew;
-    init(_coffee) {
-        this.coffee = _coffee;
-    }
+    var coffee; 
+    init(coffee) {}
 }
 
 var maker = CoffeeMaker(""coffee and chicory"");
@@ -449,9 +443,8 @@ maker.brew();");
         {
             testEngine.Run(@"
 class CoffeeMaker {
-    init(_coffee) {
-        this.coffee = _coffee;
-    }
+    var coffee; 
+    init(coffee) {}
 
     brew() {
         print (""Enjoy your cup of "" + this.coffee);
@@ -718,7 +711,7 @@ print(res.a);");
         }
 
         [Test]
-        public void Init_WhenCreatingField_ShouldSucceed()
+        public void Init_AttempCreateField_ShouldFail()
         {
             testEngine.Run(@"
 class T
@@ -729,7 +722,7 @@ class T
 var t = T();
 print(t.a);");
 
-            Assert.AreEqual("1", testEngine.InterpreterResult);
+            StringAssert.StartsWith("Attempted to create a new entry", testEngine.InterpreterResult);
         }
 
         [Test]
@@ -738,7 +731,7 @@ print(t.a);");
             testEngine.Run(@"
 class T
 {
-    init(){this.name = ""name"";}
+    var name = ""name"";
     Say(){print (this.name);}
 }
 var t = T();
@@ -753,7 +746,7 @@ t.Say();");
             testEngine.Run(@"
 class T
 {
-    init(){this.a = 1;}
+    var a = 1;
     Set(v)
     {
         this.a = v;
@@ -773,7 +766,7 @@ print (t.a);");
             testEngine.Run(@"
 class T
 {
-    init(){this.a = 1;}
+    var a = 1;
     Set()
     {
      this.a = 7;
@@ -793,7 +786,7 @@ print (t.a);");
             testEngine.Run(@"
 class T
 {
-    init(){this.a = 1;}
+    var a = 1;
     Set()
     {
         this.a = 7;

--- a/ulox/ulox.core.tests/FreezeTests.cs
+++ b/ulox/ulox.core.tests/FreezeTests.cs
@@ -35,21 +35,6 @@ inst.a = 10;");
         }
 
         [Test]
-        public void InstanceFromClass_WhenHasInitAndNoVars_ShouldSucceed()
-        {
-            testEngine.Run(@"
-class CoffeeMaker 
-{
-    init(_a) { this.a = _a; }
-}
-
-var maker = CoffeeMaker(""black"");
-print(maker.a);");
-
-            Assert.AreEqual("black", testEngine.InterpreterResult);
-        }
-
-        [Test]
         public void Class_WhenFrozenAndNonExistingFieldWritten_ShouldPreventChangeAndLog()
         {
             testEngine.Run(@"

--- a/ulox/ulox.core.tests/NativeCallTests.cs
+++ b/ulox/ulox.core.tests/NativeCallTests.cs
@@ -172,9 +172,9 @@ Locals();");
             NativeCallResult Func(Vm vm)
             {
                 var index = 0;
-                var a = vm.GetNextArg(ref index).val.asString;
-                var b = vm.GetNextArg(ref index).val.asString;
-                var c = vm.GetNextArg(ref index).val.asString;
+                var a = vm.GetArg(++index).val.asString;
+                var b = vm.GetArg(++index).val.asString;
+                var c = vm.GetArg(++index).val.asString;
                 vm.SetNativeReturn(0, Value.New($"Hello, {a}, {b}, and {c}, I'm native."));
                 return NativeCallResult.SuccessfulExpression;
             }

--- a/ulox/ulox.core.tests/uloxs/Samples/06-Class Features.ulox
+++ b/ulox/ulox.core.tests/uloxs/Samples/06-Class Features.ulox
@@ -1,15 +1,16 @@
 // init is called when an instance is created
 class WithInitVal
 {
+	var someValue;
 	init(val)
 	{
 		// this keyword gets access to the instance currently running the method
-		this.val = val;
+		this.someValue = val;
 	}
 }
 
 var foo = WithInitVal(7);
-print(foo.val);
+print(foo.someValue);
 
 // class vars are initialised prior to init
 class WithVars

--- a/ulox/ulox.core.tests/uloxs/Tests/Classes.ulox
+++ b/ulox/ulox.core.tests/uloxs/Tests/Classes.ulox
@@ -8,6 +8,8 @@ class Method
 
 class WithInit
 {
+    var a,b;
+    
     init(a,b)
     {
         this.a = a;

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compiler.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compiler.cs
@@ -49,8 +49,8 @@ namespace ULox
                 new EnumTypeCompliette()
                 );
 
-            this.AddDeclarationCompilette(
-                (TokenType.FUNCTION, FunctionDeclaration));
+
+            AddDeclarationCompilette(new CompiletteAction(TokenType.FUNCTION, FunctionDeclaration));
 
             this.AddStatementCompilette(
                 new ReturnStatementCompilette(),

--- a/ulox/ulox.core/Package/Runtime/Compiler/CompilerExt.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/CompilerExt.cs
@@ -2,11 +2,6 @@
 {
     public static class CompilerExt
     {
-        public static void AddDeclarationCompilette(this Compiler comp, (TokenType match, System.Action<Compiler> action) processAction)
-        {
-            comp.AddDeclarationCompilette(new CompiletteAction(processAction.match, processAction.action));
-        }
-
         public static void AddDeclarationCompilette(this Compiler comp, params ICompilette[] compilettes)
         {
             foreach (var item in compilettes)
@@ -15,16 +10,11 @@
             }
         }
 
-        public static void AddStatementCompilette(this Compiler comp, (TokenType match, System.Action<Compiler> action) processAction)
-        {
-            comp.AddStatementCompilette(new CompiletteAction(processAction.match, processAction.action));
-        }
-
         public static void AddStatementCompilette(this Compiler comp, params (TokenType match, System.Action<Compiler> action)[] processActions)
         {
             foreach (var item in processActions)
             {
-                comp.AddStatementCompilette(item);
+                comp.AddStatementCompilette(new CompiletteAction(item.match, item.action));
             }
         }
 

--- a/ulox/ulox.core/Package/Runtime/Engine/Engine.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/Engine.cs
@@ -10,7 +10,7 @@ namespace ULox
         public Engine(Context executionContext)
         {
             Context = executionContext;
-            Context.Vm.SetEngine(this);
+            Context.Vm.Engine = this;
             Context.AddLibrary(new StdLibrary());
         }
 

--- a/ulox/ulox.core/Package/Runtime/Engine/Program.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/Program.cs
@@ -12,7 +12,6 @@ namespace ULox
 
         public List<CompiledScript> CompiledScripts { get; } = new List<CompiledScript>();
 
-
         public string Disassembly
         {
             get

--- a/ulox/ulox.core/Package/Runtime/Library/Classes/DynamicClass.cs
+++ b/ulox/ulox.core/Package/Runtime/Library/Classes/DynamicClass.cs
@@ -13,6 +13,13 @@
                                   );
         }
 
+        public override InstanceInternal MakeInstance()
+        {
+            var res = base.MakeInstance();
+            res.Unfreeze();
+            return res;
+        }
+
         private NativeCallResult HasField(Vm vm)
         {
             var obj = vm.GetArg(1);
@@ -43,12 +50,6 @@
             inst.Fields.Remove(fieldNameStr);
 
             return NativeCallResult.SuccessfulExpression;
-        }
-
-        public override void FinishCreation(InstanceInternal inst)
-        {
-            base.FinishCreation(inst);
-            inst.Unfreeze();
         }
     }
 }

--- a/ulox/ulox.core/Package/Runtime/Library/Classes/VMClass.cs
+++ b/ulox/ulox.core/Package/Runtime/Library/Classes/VMClass.cs
@@ -11,7 +11,7 @@ namespace ULox
         public VMClass(Func<Vm> createVM) : base(new HashedString("VM"), UserType.Native)
         {
             CreateVM = createVM;
-            this.AddMethod(ClassTypeCompilette.InitMethodName, Value.New(InitInstance, 1, 0), null);
+            AddMethod(ClassTypeCompilette.InitMethodName, Value.New(InitInstance, 1, 0), null);
             this.AddMethodsToClass(
                 (nameof(AddGlobal), Value.New(AddGlobal, 1, 2)),
                 (nameof(GetGlobal), Value.New(GetGlobal, 1, 1)),
@@ -20,6 +20,7 @@ namespace ULox
                 (nameof(CopyBackToEnclosing), Value.New(CopyBackToEnclosing, 1, 0)),
                 (nameof(Resume), Value.New(Resume, 1, 0))
                                   );
+            AddFieldName(VMFieldName);
         }
 
         private NativeCallResult InitInstance(Vm vm)
@@ -67,7 +68,7 @@ namespace ULox
             Vm ourVM = GetArg0Vm(vm);
             var chunk = vm.GetArg(1).val.asClosure.chunk;
             ourVM.Interpret(chunk);
-            vm.SetNativeReturn(0, ourVM.StackTop);
+            vm.SetNativeReturn(0, ourVM.ValueStack.Peek());
             return NativeCallResult.SuccessfulExpression;
         }
 
@@ -75,7 +76,7 @@ namespace ULox
         {
             Vm ourVM = GetArg0Vm(vm);
             ourVM.Run();
-            vm.SetNativeReturn(0, ourVM.StackTop);
+            vm.SetNativeReturn(0, ourVM.ValueStack.Peek());
             return NativeCallResult.SuccessfulExpression;
         }
 

--- a/ulox/ulox.core/Package/Runtime/Types/UserTypeInternal.cs
+++ b/ulox/ulox.core/Package/Runtime/Types/UserTypeInternal.cs
@@ -93,7 +93,15 @@ namespace ULox
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public virtual InstanceInternal MakeInstance()
         {
-            return new InstanceInternal(this);
+            var ret = new InstanceInternal(this);
+
+            foreach (var fieldName in _fieldsNames)
+            {
+                ret.SetField(fieldName, Value.Null());
+            }
+
+            ret.Freeze();
+            return ret;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -155,10 +163,6 @@ namespace ULox
         {
             return overloadableOperators[OpCodeToOverloadIndex[opCode]];
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public virtual void FinishCreation(InstanceInternal inst)
-            => inst.Freeze();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AddFieldName(HashedString fieldName)


### PR DESCRIPTION
Instances are now frozen before entering init, their fields defaulting to null before it is run.
Init auto assign of matching var names is now sugar rather than a vm feature.

Remember to Add/Update the:
- [x] Sample scripts
- [x] Test scripts
