### PR TITLE
Merge auto-fields-in-methods into main: Remove need for this on class vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ class MyFoo
     {
         this.a = arg;
     }
+
+    //you can omit the this. for fields of the instance
+    Baz(arg)
+    {
+        a = arg;
+    }
 }
 
 //to get an instance of the class, we invoke it's name and match it's init args

--- a/ulox/ulox.core.tests/ClassTests.cs
+++ b/ulox/ulox.core.tests/ClassTests.cs
@@ -1719,5 +1719,25 @@ var
 
             Assert.AreEqual("", testEngine.InterpreterResult);
         }
+
+        [Test]
+        public void Field_InMethodWithoutThis_ShouldAutoLocate()
+        {
+            testEngine.Run(@"
+class CoffeeMaker {
+    var coffee; 
+    init(coffee) {}
+
+    brew() {
+        print (""Enjoy your cup of {coffee}"");
+        coffee = null;
+    }
+}
+
+var maker = CoffeeMaker(""coffee and chicory"");
+maker.brew();");
+
+            Assert.AreEqual("Enjoy your cup of coffee and chicory", testEngine.InterpreterResult);
+        }
     }
 }

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ClassTypeCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/ClassTypeCompilette.cs
@@ -93,9 +93,10 @@ namespace ULox
                     var argName = compiler.CurrentCompilerState.chunk.ReadConstant(argId).val.asString.String;
                     if (CurrentTypeInfoEntry.Fields.FirstOrDefault(x => x == argName) != null)
                     {
-                        var (_1,_2, id) = compiler.ResolveNameLookupOpCode(argName);
-                        compiler.EmitPacket(new ByteCodePacket(OpCode.GET_LOCAL, (byte)0));
-                        compiler.EmitPacket(new ByteCodePacket(OpCode.GET_LOCAL, (byte)id));
+                        var argResolveRes = compiler.ResolveNameLookupOpCode(argName);
+                        var thisResolveRes = compiler.ResolveNameLookupOpCode(ThisName.String);
+                        compiler.EmitPacketFromResolveGet(thisResolveRes);
+                        compiler.EmitPacketFromResolveGet(argResolveRes);
                         compiler.EmitPacket(new ByteCodePacket(OpCode.SET_PROPERTY, (byte)argId));
                         compiler.EmitPop();
                     }

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/LoopStatementCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/LoopStatementCompilette.cs
@@ -16,7 +16,7 @@
             //temp
             compiler.TokenIterator.Consume(TokenType.IDENTIFIER, "Expect identifier after loop statement with arg.");
             var arrayName = compiler.TokenIterator.PreviousToken.Lexeme;
-            var (arrayGetOp, _, arrayArgId) = compiler.ResolveNameLookupOpCode(arrayName);
+            var arrayResolveRes = compiler.ResolveNameLookupOpCode(arrayName);
             var itemName = "item";
             var itemArgID = (byte)0;
             var indexName = "i";
@@ -53,13 +53,13 @@
             }
 
             //skip the loop if the target is null
-            compiler.EmitPacket(new ByteCodePacket(arrayGetOp, arrayArgId));
+            compiler.EmitPacketFromResolveGet(arrayResolveRes);
             compiler.EmitGotoIf(loopState.ExitLabelID);
             loopState.HasExit = true;
             compiler.EmitPop();
 
             //prep count
-            compiler.EmitPacket(new ByteCodePacket(arrayGetOp, arrayArgId));
+            compiler.EmitPacketFromResolveGet(arrayResolveRes);
             compiler.EmitPacket(new ByteCodePacket(OpCode.COUNT_OF));
             compiler.EmitPacket(new ByteCodePacket(OpCode.SET_LOCAL, countNameID));
             compiler.EmitPop();
@@ -85,10 +85,9 @@
                 loopState.StartLabelID = newStartLabel;
                 compiler.EmitLabel(bodyJump);
             }
-
             //prep item infront of body
             {
-                compiler.EmitPacket(new ByteCodePacket(arrayGetOp, arrayArgId));
+                compiler.EmitPacketFromResolveGet(arrayResolveRes);
                 compiler.EmitPacket(new ByteCodePacket(OpCode.GET_LOCAL, indexArgID));
                 compiler.EmitPacket(new ByteCodePacket(OpCode.GET_INDEX));
                 compiler.EmitPacket(new ByteCodePacket(OpCode.SET_LOCAL, itemArgID));

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TestcaseCompillette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TestcaseCompillette.cs
@@ -6,6 +6,9 @@
         public string TestCaseName { get; private set; }
 
         private const string AnonTestPrefix = "Anon_Test_";
+        private const string TestDataSourceVarName = "testDataSource";
+        private const string TestDataRowVarName = "testDataRow";
+        private const string TestDataIndexVarName = "testDataIndex";
         private readonly TestSetDeclarationCompilette _testDeclarationCompilette;
 
         public TestcaseCompillette(TestSetDeclarationCompilette testDeclarationCompilette)
@@ -32,15 +35,15 @@
                 dataExpExecuteLocation = compiler.LabelUniqueChunkLabel("DataExpExecuteLocation");
 
                 //expression
-                compiler.DeclareAndDefineCustomVariable("testDataSource");
+                compiler.DeclareAndDefineCustomVariable(TestDataSourceVarName);
                 compiler.EmitNULL();
-                compiler.DeclareAndDefineCustomVariable("testDataRow");
+                compiler.DeclareAndDefineCustomVariable(TestDataRowVarName);
                 compiler.EmitNULL();
-                compiler.DeclareAndDefineCustomVariable("testDataIndex");
+                compiler.DeclareAndDefineCustomVariable(TestDataIndexVarName);
                 compiler.EmitPacket(new ByteCodePacket(new ByteCodePacket.PushValueDetails(0)));
                 compiler.Expression();
-                var (_, _, res) = compiler.ResolveNameLookupOpCode("testDataSource");
-                testDataSourceLocalId = res;
+                var res = compiler.ResolveLocal(TestDataSourceVarName);
+                testDataSourceLocalId = (byte)res;
                 compiler.EmitPacket(new ByteCodePacket(OpCode.SET_LOCAL, testDataSourceLocalId));
                 compiler.EmitPop();
 
@@ -84,7 +87,7 @@
 
                 //need to deal with the args
                 //get testset data row
-                var (_, _, testDataIndexLocalIdRes) = compiler.ResolveNameLookupOpCode("testDataIndex");
+                var testDataIndexLocalIdRes = compiler.ResolveLocal(TestDataIndexVarName);
                 testDataIndexLocalId = testDataIndexLocalIdRes;
 
                 preRowCountCheck = compiler.LabelUniqueChunkLabel("preRowCountCheck");
@@ -97,7 +100,7 @@
                 compiler.EmitPacket(new ByteCodePacket(OpCode.GET_LOCAL, testDataSourceLocalId));
                 compiler.EmitPacket(new ByteCodePacket(OpCode.GET_LOCAL, testDataIndexLocalId));
                 compiler.EmitPacket(new ByteCodePacket(OpCode.GET_INDEX));
-                var (_, _, testDataRowLocalId) = compiler.ResolveNameLookupOpCode("testDataRow");
+                var testDataRowLocalId = compiler.ResolveLocal(TestDataRowVarName);
                 compiler.EmitPacket(new ByteCodePacket(OpCode.SET_LOCAL, testDataRowLocalId));
                 compiler.EmitPop();
                 //appy row as inputs to the test

--- a/ulox/ulox.core/Package/Runtime/Enums/OpCode.cs
+++ b/ulox/ulox.core/Package/Runtime/Enums/OpCode.cs
@@ -48,6 +48,8 @@
 
         GET_PROPERTY,
         SET_PROPERTY,
+        GET_FIELD,
+        SET_FIELD,
         INVOKE,
 
         FREEZE, //could collapse with READ_ONLY


### PR DESCRIPTION
Since moving to entirely frozen classes, we can now remove the need for this when accessing a field on the instance in a method.

Remember to Add/Update the:
- [ ] Sample scripts
- [ ] Test scripts
