### PR TITLE
Remove label op codes from VM

### DIFF
--- a/ulox/ulox.core.tests/ByteCodeInterpreterTestEngine.cs
+++ b/ulox/ulox.core.tests/ByteCodeInterpreterTestEngine.cs
@@ -48,6 +48,7 @@ namespace ULox.Core.Tests
                 _logger(VmUtil.GenerateGlobalsDump(MyEngine.Context.Vm));
                 _logger(VmUtil.GenerateValueStackDump(MyEngine.Context.Vm));
                 _logger(VmUtil.GenerateReturnDump(MyEngine.Context.Vm));
+                _logger(MyEngine.Context.Program.Optimiser?.OptimisationReporter?.GetReport() ?? string.Empty);
             }
         }
 

--- a/ulox/ulox.core.tests/ConditionalTests.cs
+++ b/ulox/ulox.core.tests/ConditionalTests.cs
@@ -24,6 +24,7 @@ if(1 > 2)
     print (""ERROR"");
 else
     print (""The "");
+
 print (""End"");");
 
             Assert.AreEqual("The End", testEngine.InterpreterResult);
@@ -37,6 +38,7 @@ if(1 > 2 or 2 > 3)
     print( ""ERROR"");
 else if (1 == 1 and 2 == 2)
     print (""The "");
+
 print (""End"");");
 
             Assert.AreEqual("The End", testEngine.InterpreterResult);

--- a/ulox/ulox.core.tests/ConditionalTests.cs
+++ b/ulox/ulox.core.tests/ConditionalTests.cs
@@ -7,7 +7,11 @@ namespace ULox.Core.Tests
         [Test]
         public void If_WhenFalseSingleStatementBody_ShouldSkipAfter()
         {
-            testEngine.Run(@"if(1 > 2) print (""ERROR""); print (""End"");");
+            testEngine.Run(@"
+if(1 > 2) 
+    print (""ERROR""); 
+
+print (""End"");");
 
             Assert.AreEqual("End", testEngine.InterpreterResult);
         }

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compiler.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compiler.cs
@@ -581,6 +581,7 @@ namespace ULox
         public byte LabelUniqueChunkLabel(string v)
         {
             byte labelNameID = UniqueChunkLabelStringConstant(v);
+            EmitGoto(labelNameID);
             EmitLabel(labelNameID);
             return labelNameID;
         }

--- a/ulox/ulox.core/Package/Runtime/Compiler/CompilerExpressions.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/CompilerExpressions.cs
@@ -102,24 +102,26 @@ namespace ULox
 
         public static void And(Compiler compiler, bool canAssign)
         {
-            var endJumpLabel = compiler.GotoIfUniqueChunkLabel("and");
+            var endJumpLabel = compiler.GotoIfUniqueChunkLabel("after_and");
 
             compiler.EmitPop();
             compiler.ParsePrecedence(Precedence.And);
 
+            compiler.EmitGoto(endJumpLabel);
             compiler.EmitLabel(endJumpLabel);
         }
 
         public static void Or(Compiler compiler, bool canAssign)
         {
-            var elseJumpLabel = compiler.GotoIfUniqueChunkLabel("else_or");
-            var endJump = compiler.GotoUniqueChunkLabel("or");
+            var elseJumpLabel = compiler.GotoIfUniqueChunkLabel("short_or");
+            var endJump = compiler.GotoUniqueChunkLabel("afte_or");
 
             compiler.EmitLabel(elseJumpLabel);
             compiler.EmitPop();
 
             compiler.ParsePrecedence(Precedence.Or);
 
+            compiler.EmitGoto(endJump);
             compiler.EmitLabel(endJump);
         }
 

--- a/ulox/ulox.core/Package/Runtime/Compiler/CompilerStatements.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/CompilerStatements.cs
@@ -39,12 +39,14 @@ namespace ULox
 
                 compiler.Statement();
 
+                compiler.EmitGoto(afterIfLabel);
                 compiler.EmitLabel(elseJump);
             }
             else
             {
                 compiler.EmitLabel(wasFalseLabel);
                 compiler.EmitPop();
+                compiler.EmitGoto(afterIfLabel);
             }
 
             compiler.EmitLabel(afterIfLabel);
@@ -275,7 +277,7 @@ namespace ULox
             var bodyJump = compiler.GotoUniqueChunkLabel("loop_body");
             //increment
             {
-                var newStartLabel = compiler.LabelUniqueChunkLabel("loop_start");
+                var newStartLabel = compiler.LabelUniqueChunkLabel("loop_continue");
                 loopState.ContinueLabelID = newStartLabel;
                 if (compiler.TokenIterator.CurrentToken.TokenType != TokenType.CLOSE_PAREN)
                 {

--- a/ulox/ulox.core/Package/Runtime/Compiler/CompilerStatements.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/CompilerStatements.cs
@@ -23,7 +23,7 @@ namespace ULox
             compiler.TokenIterator.Consume(TokenType.CLOSE_PAREN, "Expect ')' after if.");
 
             //todo can we make goto_if consume the value in the vm so we don't need to play pop wackamole
-            var thenjumpLabel = compiler.GotoIfUniqueChunkLabel("if_false");
+            var wasFalseLabel = compiler.GotoIfUniqueChunkLabel("if_false");
             compiler.EmitPop();
 
             compiler.Statement();
@@ -34,7 +34,7 @@ namespace ULox
             {
                 var elseJump = compiler.GotoUniqueChunkLabel("else");
 
-                compiler.EmitLabel(thenjumpLabel);
+                compiler.EmitLabel(wasFalseLabel);
                 compiler.EmitPop();
 
                 compiler.Statement();
@@ -43,7 +43,7 @@ namespace ULox
             }
             else
             {
-                compiler.EmitLabel(thenjumpLabel);
+                compiler.EmitLabel(wasFalseLabel);
                 compiler.EmitPop();
             }
 

--- a/ulox/ulox.core/Package/Runtime/Engine/TestRunner.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/TestRunner.cs
@@ -95,7 +95,7 @@ namespace ULox
             {
                 var name = chunk.ReadConstant(b2).val.asString;
                 var label = b1;
-                var loc = (ushort)chunk.Labels[label];
+                var loc = chunk.GetLabelPosition(label);
 
                 CurrentTestSetName = name;
                 if (Enabled)
@@ -111,7 +111,7 @@ namespace ULox
                 break;
             case TestOpType.TestFixtureBodyInstruction:
             {
-                var loc = (ushort)chunk.Labels[b1];
+                var loc = chunk.GetLabelPosition(b1);
                 SetFixtureLoc(loc);
             }
             break;

--- a/ulox/ulox.core/Package/Runtime/Engine/VM.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/VM.cs
@@ -485,6 +485,7 @@ namespace ULox
                     break;
 
                 case OpCode.LABEL:
+                    ThrowRuntimeException($"Unexpected OpCode '{opCode}'");
                     break;
 
                 case OpCode.ENUM_VALUE:
@@ -1273,7 +1274,7 @@ namespace ULox
                 PushNewCallframe(new CallFrame()
                 {
                     Closure = new ClosureInternal { chunk = chunk },
-                    InstructionPointer = chunk.Labels[labelID],
+                    InstructionPointer = chunk.GetLabelPosition(labelID),
                     StackStart = (byte)(_valueStack.Count - 1), //last thing checked
                 });
             }

--- a/ulox/ulox.core/Package/Runtime/Engine/VM.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/VM.cs
@@ -484,10 +484,6 @@ namespace ULox
                         _currentCallFrame.InstructionPointer = chunk.GetLabelPosition(packet.b1);
                     break;
 
-                case OpCode.LABEL:
-                    ThrowRuntimeException($"Unexpected OpCode '{opCode}'");
-                    break;
-
                 case OpCode.ENUM_VALUE:
                 {
                     var (enumObject, val, key) = Pop3OrLocals(packet.b1, packet.b2, packet.b3);

--- a/ulox/ulox.core/Package/Runtime/Optimiser/ByteCodeOptimiser.cs
+++ b/ulox/ulox.core/Package/Runtime/Optimiser/ByteCodeOptimiser.cs
@@ -18,13 +18,14 @@ namespace ULox
 
         public bool Enabled { get; set; } = true;
         public bool EnableLocalizing { get; set; } = true;
-        public bool EnableDeadCodeRemoval{ get; set; } = true;
-        public bool EnableRemoveUnreachableLabels { get; set; } = false;
+        public bool EnableDeadCodeRemoval { get; set; } = true;
+        public bool EnableZeroJumpGotoRemoval{ get; set; } = true;
 
         public OptimisationReporter OptimisationReporter { get; set; }
         private List<(Chunk chunk, int inst)> _toRemove = new List<(Chunk, int)>();
         private List<(Chunk chunk, int inst, RegisteriseType regType)> _potentialRegisterise = new List<(Chunk, int, RegisteriseType)>();
         private readonly List<(Chunk chunk, int from, byte label)> _labelUsage = new List<(Chunk, int, byte)>();
+        private List<(Chunk chunk, int inst)> _gotos = new List<(Chunk chunk, int inst)>();
         private OpCode _prevOoCode;
         private int _deadCodeStart = -1;
 
@@ -36,11 +37,7 @@ namespace ULox
             OptimisationReporter?.PreOptimise(compiledScript);
             Iterate(compiledScript);
             if (EnableLocalizing) AttemptRegisterise();
-            if (EnableRemoveUnreachableLabels)
-            {
-                MarkNoJumpGotoLabelAsDead();
-                MarkUnsedLabelsAsDead(compiledScript, typeInfo);
-            }
+            if (EnableZeroJumpGotoRemoval) MarkZeroJumpGotoForRemoval();
             RemoveMarkedInstructions();
             OptimisationReporter?.PostOptimise(compiledScript);
         }
@@ -57,11 +54,48 @@ namespace ULox
             }
         }
 
+        private void MarkZeroJumpGotoForRemoval()
+        {
+            //want to do this in reverse order so we can mark things as to remove in longer forward stretches
+            _gotos = _gotos.OrderByDescending(x => x.inst).ToList();
+
+            //todo check that gotos have alive code to actually skip, if not add them to the toremove
+            foreach (var (chunk, inst) in _gotos)
+            {
+                //if behind us skip
+                var labelId = chunk.Instructions[inst].b1;
+                var labelLoc = chunk.Labels[labelId];
+                if (inst > labelLoc)
+                    continue;
+
+                //if already skipped
+                if (_toRemove.Any(x => x.chunk == chunk && x.inst == inst))
+                    continue;
+
+                //are all ops between us and the label marked as toremove?
+                var found = false;
+                for (int i = inst + 1; i < labelLoc; i++)
+                {
+                    if (!_toRemove.Any(d => d.chunk == chunk && d.inst == i))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                {
+                    _toRemove.Add((chunk, inst));
+                }
+            }
+        }
+
         public void Reset()
         {
             _toRemove.Clear();
             _potentialRegisterise.Clear();
             _labelUsage.Clear();
+            _gotos.Clear();
             _deadCodeStart = -1;
         }
 
@@ -100,6 +134,7 @@ namespace ULox
                 break;
             case OpCode.GOTO:
             case OpCode.GOTO_IF_FALSE:
+                AddGotoLabel((CurrentChunk, CurrentInstructionIndex));
                 AddLabelUsage(packet.b1);
                 break;
             case OpCode.ADD:
@@ -128,6 +163,9 @@ namespace ULox
             case OpCode.SET_PROPERTY:
                 _potentialRegisterise.Add((CurrentChunk, CurrentInstructionIndex, RegisteriseType.SetProp));
                 break;
+            case OpCode.LABEL:
+                _toRemove.Add((CurrentChunk, CurrentInstructionIndex));
+                break;
             }
         }
 
@@ -138,6 +176,11 @@ namespace ULox
         private void AddLabelUsage(byte labelId)
         {
             _labelUsage.Add((CurrentChunk, CurrentInstructionIndex, labelId));
+        }
+
+        private void AddGotoLabel((Chunk chunk, int instruction) value)
+        {
+            _gotos.Add(value);
         }
 
         private void AttemptRegisterise()
@@ -240,49 +283,6 @@ namespace ULox
                 }
 
                 chunk.Instructions[inst] = new ByteCodePacket(original.OpCode, nb1, nb2, nb3);
-            }
-        }
-
-        private void MarkNoJumpGotoLabelAsDead()
-        {
-            foreach (var (chunk, from, label) in _labelUsage)
-            {
-                var labelLoc = chunk.Labels[label];
-
-                if (from - 1 >= labelLoc)
-                    continue;
-
-                var found = false;
-                for (int i = from + 1; i < labelLoc; i++)
-                {
-                    if (!_toRemove.Any(d => d.chunk == chunk && d.inst == i))
-                    {
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (!found)
-                {
-                    _toRemove.Add((chunk, from));
-                }
-            }
-        }
-
-        private void MarkUnsedLabelsAsDead(CompiledScript compiledScript, TypeInfo typeInfo)
-        {
-            foreach (var chunk in compiledScript.AllChunks)
-            {
-                foreach (var label in chunk.Labels)
-                {
-                    var matches = _labelUsage.Where(x => x.chunk == chunk && x.label == label.Key);
-                    var used = matches.Any(x => !_toRemove.Any(y => y.chunk == chunk && y.inst == x.from));
-                    var usedByTypes = typeInfo?.Types.Any(x => x.InitChains.Any(y => y.chunk == chunk && y.labelID == label.Key)) ?? false;
-                    if (!used && !usedByTypes)
-                    {
-                        _toRemove.Add((chunk, label.Value));
-                    }
-                }
             }
         }
     }

--- a/ulox/ulox.core/Package/Runtime/Types/Chunk.cs
+++ b/ulox/ulox.core/Package/Runtime/Types/Chunk.cs
@@ -149,9 +149,9 @@ namespace ULox
             return locationName;
         }
 
-        internal int GetLabelPosition(byte labelID)
+        public ushort GetLabelPosition(byte labelID)
         {
-            return _labelIdToInstruction[labelID];
+            return (ushort)(_labelIdToInstruction[labelID] + 1);
         }
 
         internal void AddLabel(byte id, int currentChunkInstructinCount)


### PR DESCRIPTION
Started by skipping to the packet after the label to reduce the no op at runtime. Optimiser removes them and adjacent zero jump gotos

close #198