### PR TITLE
Merge dyn-prop into main: Add support for dynamically using fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,12 @@ class MyFooAndThenSome
 var matchingShape1 = anAddress meets Address(); //will be true
 var matchingShape2 = anAddress meets myFoo(); //will be false
 
+//ulox also supports the use of fields via subscript syntax.
+//  This allows for code that does not know the identifier ahead
+//  of time to be written.
+var someFieldNameWeDidntKnow = "a";
+myFoo[someFieldNameWeDidntKnow] = 7; 
+
 //testing is built into the language, 
 //  they are setup like test fixtures with test cases.
 //  They are auto run by the vm, in an isolated inner vm. 

--- a/ulox/ulox.core.tests/DynamicTests.cs
+++ b/ulox/ulox.core.tests/DynamicTests.cs
@@ -102,9 +102,8 @@ obj.RemoveField(obj, ""a"");");
             StringAssert.StartsWith("Cannot remove field from read only", testEngine.InterpreterResult);
         }
 
-        //todo add more tests for dynamic_property
         [Test]
-        public void DyanicProperty_Exists_ShouldMatch()
+        public void DyanicProperty_GetExists_ShouldMatch()
         {
             testEngine.Run(@"
 var foo = { a = 1 };
@@ -114,6 +113,59 @@ print(res);");
             Assert.AreEqual("1", testEngine.InterpreterResult);
         }
 
-        //todo rather than dynprop, what if we just allowed foo["a"] to resolve via get_index on a non-list?
+        [Test]
+        public void DyanicProperty_GetDoesNotExists_ShouldError()
+        {
+            testEngine.Run(@"
+var foo = { a = 1 };
+var res = foo[""b""];
+print(res);");
+
+            StringAssert.StartsWith("No field of name 'b' could be found on instance", testEngine.InterpreterResult);
+        }
+
+        [Test]
+        public void DyanicProperty_GetInvalidType_ShouldError()
+        {
+            testEngine.Run(@"
+var foo = 7;
+var res = foo[""b""];
+print(res);");
+
+            StringAssert.StartsWith("Cannot perform get index on type 'Double'", testEngine.InterpreterResult);
+        }
+
+        [Test]
+        public void DyanicProperty_SetExists_ShouldMatch()
+        {
+            testEngine.Run(@"
+var foo = { a = 1 };
+foo[""a""] = 2;
+print(foo.a);");
+
+            Assert.AreEqual("2", testEngine.InterpreterResult);
+        }
+
+        [Test]
+        public void DyanicProperty_SetDoesNotExists_ShouldError()
+        {
+            testEngine.Run(@"
+var foo = { a = 1 };
+foo[""b""] = 2;
+print(foo.a);");
+
+            StringAssert.StartsWith("Attempted to create a new entry 'b' via Set.", testEngine.InterpreterResult);
+        }
+
+        [Test]
+        public void DyanicProperty_SetInvalidType_ShouldError()
+        {
+            testEngine.Run(@"
+var foo = 7;
+foo[""b""] = 2;
+print(foo.a);");
+
+            StringAssert.StartsWith("Cannot perform set index on type 'Double'", testEngine.InterpreterResult);
+        }
     }
 }

--- a/ulox/ulox.core.tests/DynamicTests.cs
+++ b/ulox/ulox.core.tests/DynamicTests.cs
@@ -101,5 +101,19 @@ obj.RemoveField(obj, ""a"");");
 
             StringAssert.StartsWith("Cannot remove field from read only", testEngine.InterpreterResult);
         }
+
+        //todo add more tests for dynamic_property
+        [Test]
+        public void DyanicProperty_Exists_ShouldMatch()
+        {
+            testEngine.Run(@"
+var foo = { a = 1 };
+var res = foo[""a""];
+print(res);");
+
+            Assert.AreEqual("1", testEngine.InterpreterResult);
+        }
+
+        //todo rather than dynprop, what if we just allowed foo["a"] to resolve via get_index on a non-list?
     }
 }

--- a/ulox/ulox.core.tests/JsonSerialisationTests.cs
+++ b/ulox/ulox.core.tests/JsonSerialisationTests.cs
@@ -222,5 +222,83 @@ var res = Serialise.FromJson(jsonString);
 
             Assert.AreEqual("", testEngine.InterpreterResult);
         }
+
+        [Test]
+        public void SerialiseToJson_WhenComplextDataStore_ShouldBeSuccess()
+        {
+            testEngine.Run(@"
+class ShipCharacter
+{
+var
+    accel = 20,
+    throttleAccel = 2,
+    maxSpeed = 12,
+    turnPerSecondThrust = 190,
+    turnPerSecondFreeSpin = 290,
+    gravity = 10,
+    dragSharpness = 0.5,
+    sidewaysDragSharpness = 3,
+    backwardDragSharpness = 1.5,
+    mass = 1,
+    fireRate = 0.5,
+    kickback = 1,
+    projectileSpeed = 10,
+    projectileTtl = 1,
+    projectileSpeedInher = 0.5,
+    maxHealth = 5,
+    invulnTime = -1, 
+    timeTilRegen = 0,
+    healthRegenRate = -1,
+    healthRegenFreeSpinRate = -1,
+    shotName = ""PlayerSmallShot"",
+    weaponType = ""PlayerBullet"",
+    weaponCreator = fun(fromShip){},
+    pipLifetime = 20,
+    pipPickupRange = 1,
+    pipAttractRange = 15,
+    pipAttractForce = 20,
+    pipsWhenDestroyed = 0,
+    sizeRadius = 1,
+    waterDisplacement = 20,
+    rudderAccel = 2,
+}
+
+var enemyShipData = 
+{
+    EnemyA = ShipCharacter() update 
+    {
+        fireRate = 1,
+        accel = 25,
+        maxSpeed = 14,
+        turnPerSecondThrust = 290,
+        turnPerSecondNoThrust = 380,
+        shotName = ""EnemySmallShot"",
+        weaponType = ""EnemyBullet"",
+        pipsWhenDestroyed = 1,
+        sizeRadius = 0.25,
+        waterDisplacement = 5,
+        rudderAccel = 3,
+    },
+    EnemyB = ShipCharacter() update 
+    {
+        fireRate = 0.2,
+        accel = 15,
+        maxSpeed = 9,
+        shotName = ""EnemySmallShot"",
+        weaponType = ""EnemyBullet"",
+        projectileSpeed = 15,
+        projectileSpeedInher = 1,
+        pipsWhenDestroyed = 2,
+        sizeRadius = 1.5,
+        waterDisplacement = 10,
+        rudderAccel = 1,
+    },
+};
+
+print(Serialise.ToJson(enemyShipData));
+");
+
+            StringAssert.StartsWith("{\r\n  \"EnemyA\": {\r\n    \"accel\": 25.0,", testEngine.InterpreterResult);
+        }
     }
 }

--- a/ulox/ulox.core.tests/SimpleStringSerialisationTests.cs
+++ b/ulox/ulox.core.tests/SimpleStringSerialisationTests.cs
@@ -1,6 +1,5 @@
 ﻿using NUnit.Framework;
 using System.Text.RegularExpressions;
-using ULox;
 
 namespace ULox.Core.Tests
 {

--- a/ulox/ulox.core/Package/Runtime/Engine/VM.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/VM.cs
@@ -517,7 +517,7 @@ namespace ULox
                 case OpCode.SET_INDEX:
                 {
                     var (newValue, index, listValue) = Pop3OrLocals(packet.b1, packet.b2, packet.b3);
-                    DoSetIndexOp(opCode, newValue, index, listValue);
+                    DoSetIndexOp(newValue, index, listValue);
                 }
                 break;
 
@@ -686,16 +686,25 @@ namespace ULox
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void DoSetIndexOp(OpCode opCode, Value newValue, Value index, Value listValue)
+        private void DoSetIndexOp(Value newValue, Value indexOrName, Value target)
         {
-            if (listValue.val.asInstance is INativeCollection nativeCol)
+            if (target.type == ValueType.Instance)
             {
-                nativeCol.Set(index, newValue);
+                if (target.val.asInstance is INativeCollection nativeCol)
+                {
+                    nativeCol.Set(indexOrName, newValue);
+                }
+                else
+                {
+                    var inst = target.val.asInstance;
+                    inst.Fields.Set(indexOrName.val.asString, newValue);
+                }
+
                 Push(newValue);
                 return;
             }
 
-            ThrowRuntimeException($"Cannot perform set index on type '{listValue.type}'");
+            ThrowRuntimeException($"Cannot perform set index on type '{target.type}'");
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/ulox/ulox.core/Package/Runtime/Library/Serialise/ValueHeirarchyWalker.cs
+++ b/ulox/ulox.core/Package/Runtime/Library/Serialise/ValueHeirarchyWalker.cs
@@ -52,12 +52,17 @@ namespace ULox
 
                 break;
 
-            default:
+            case ValueType.Double:
+            case ValueType.Bool:
+            case ValueType.String:
+            case ValueType.Null:
                 if (name != null)
                     _writer.WriteNameAndValue(name.String, v);
                 else
                     _writer.WriteValue(v);
 
+                break;
+            default:
                 break;
             }
         }


### PR DESCRIPTION
Add support for get and set of fields via an expression rather than identifier, primarily useful for using indexing values on a dynamic object being using as a map/datastore.