### PR TITLE
Merge fix-mac-tests into main: Correct tests to work with mac newlines

### DIFF
--- a/ulox/ulox.core.tests/JsonSerialisationTests.cs
+++ b/ulox/ulox.core.tests/JsonSerialisationTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using System;
 using System.IO;
 using System.Text.RegularExpressions;
 
@@ -298,7 +299,9 @@ var enemyShipData =
 print(Serialise.ToJson(enemyShipData));
 ");
 
-            StringAssert.StartsWith("{\r\n  \"EnemyA\": {\r\n    \"accel\": 25.0,", testEngine.InterpreterResult);
+            StringAssert.StartsWith("{" + Environment.NewLine 
+            + "  \"EnemyA\": {"+ Environment.NewLine
+            + "    \"accel\": 25.0,", testEngine.InterpreterResult);
         }
     }
 }


### PR DESCRIPTION
Fix direct use of newlines in tests