### PR TITLE
Merge fix-bad-var-decl-error into main: Correct error message on missing =  

### DIFF
--- a/ulox/ulox.core.tests/CompileErrorTests.cs
+++ b/ulox/ulox.core.tests/CompileErrorTests.cs
@@ -1,0 +1,22 @@
+﻿using NUnit.Framework;
+
+namespace ULox.Core.Tests
+{
+    [TestFixture]
+    public class CompileErrorTests : EngineTestBase
+    {
+        [Test]
+        public void Var_MissingAssignOrSemi_Error()
+        {
+            testEngine.Run(@"
+//var with missing assign followed by blocks should error
+var foo
+{
+    [1,2,3,4,5,6,],
+};  
+");
+
+            StringAssert.StartsWith("Expect ; after VarDeclaration", testEngine.InterpreterResult);
+        }
+    }
+}

--- a/ulox/ulox.core.tests/DesugarTests.cs
+++ b/ulox/ulox.core.tests/DesugarTests.cs
@@ -315,7 +315,7 @@ soa FooSoa
             var script = new Script("test", scriptContent);
             var tokenisedScript = scanner.Scan(script);
             var context = new DummyContext();
-            var tokenIterator = new TokenIterator(tokenisedScript, context);
+            var tokenIterator = new TokenIterator(tokenisedScript, context, null);
             return (tokenisedScript.Tokens, tokenIterator, context);
         }
 

--- a/ulox/ulox.core.tests/PlatformEngineTests.cs
+++ b/ulox/ulox.core.tests/PlatformEngineTests.cs
@@ -24,7 +24,7 @@ var fileContent = ""hello"";
 var fileLoc = ""temp:PlatformWriteTempFile_ReadTempFile_ShouldMatch.txt"";
 Platform.WriteFile(fileLoc, fileContent);
 var readBack = Platform.ReadFile(fileLoc);
-print(fileContent == readBack)");
+print(fileContent == readBack);");
 
             Assert.AreEqual("True", testEngine.InterpreterResult);
         }

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compiler.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compiler.cs
@@ -299,7 +299,7 @@ namespace ULox
         public CompiledScript Compile(TokenisedScript tokenisedScript)
         {
             _compilingScript = new CompiledScript(tokenisedScript.SourceScript.ScriptHash);
-            TokenIterator = new TokenIterator(tokenisedScript, this);
+            TokenIterator = new TokenIterator(tokenisedScript, this, this);
             TokenIterator.Advance();
 
             PushCompilerState("root", FunctionType.Script);
@@ -367,7 +367,7 @@ namespace ULox
             => _prattParser.ParsePrecedence(this, pre);
 
         public void ConsumeEndStatement([CallerMemberName] string after = default)
-            => TokenIterator.Consume(TokenType.END_STATEMENT, $"Expect ; after {after}.");
+            => TokenIterator.Consume(TokenType.END_STATEMENT, $"Expect ; after {after}");
 
         public void PushCompilerState(string name, FunctionType functionType)
         {

--- a/ulox/ulox.core/Package/Runtime/Compiler/TokenIterator.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/TokenIterator.cs
@@ -28,6 +28,7 @@ namespace ULox
         public Token PreviousToken { get; private set; }
         public string SourceName => _tokeisedScript.SourceScript.Name;
 
+        private readonly Compiler _compiler;
         private readonly TokenisedScript _tokeisedScript;
         private readonly ICompilerDesugarContext _compilerDesugarContext;
         private readonly List<IDesugarStep> _desugarSteps = new();
@@ -36,8 +37,10 @@ namespace ULox
 
         public TokenIterator(
             TokenisedScript tokenisedScript,
-            ICompilerDesugarContext compilerDesugarContext)
+            ICompilerDesugarContext compilerDesugarContext,
+            Compiler compiler)
         {
+            _compiler = compiler;
             _tokeisedScript = tokenisedScript;
             _compilerDesugarContext = compilerDesugarContext;
 
@@ -83,6 +86,8 @@ namespace ULox
         {
             if (CurrentToken.TokenType == tokenType)
                 Advance();
+            else
+                _compiler.ThrowCompilerException(msg);
         }
 
         public bool Check(TokenType type)


### PR DESCRIPTION
Fix error reporting on a bad partial var decl.
Token iterator was not correctly throwing compiler error when consume end was requested but not found.