### PR TITLE
Merge quotient-constants into main

### DIFF
--- a/ulox/ulox.core.tests/DoubleToQuotientTests.cs
+++ b/ulox/ulox.core.tests/DoubleToQuotientTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace ULox.Core.Tests
+{
+    [TestFixture]
+    public class DoubleToQuotientTests
+    {
+        [Test]
+        [TestCase(0.0, true, 0, 1u)]
+        [TestCase(1.0, true, 1, 1u)]
+        [TestCase(2.0, true, 2, 1u)]
+        [TestCase(0.5, true, 1, 2u)]
+        [TestCase(0.25, true, 1, 4u)]
+        [TestCase(0.75, true, 3, 4u)]
+        [TestCase(-0.75, true, -3, 4u)]
+        [TestCase(0.3333333333333333, true, 1, 3u)]
+        [TestCase(0.518518, true, 37031, 71417u)]
+        [TestCase(0.518518518518, true, 14, 27u)]
+        [TestCase(0.9054054054054, true, 67, 74u)]
+        public void Whole_WhenToQuotient_1Denom(
+            double test,
+            bool expectedPos,
+            int expectedNume,
+            uint expectedDenom)
+        {
+            var (isPossible, nume, denom) = DoubleToQuotient.ToQuotient(test, 10);//we care about best byte div so 8 is 1/256
+
+            Console.WriteLine($"expected:{expectedNume}/{expectedDenom} ({expectedNume / (double)expectedDenom})");
+            Console.WriteLine($"actual:{nume}/{(double)denom} ({nume/(double)denom})");
+            Console.WriteLine(test);
+            Console.WriteLine(nume / (double)denom);
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(expectedPos, isPossible);
+                Assert.AreEqual(expectedNume, nume);
+                Assert.AreEqual(expectedDenom, denom);
+            });
+        }
+    }
+}

--- a/ulox/ulox.core.tests/InlineConstantTests.cs
+++ b/ulox/ulox.core.tests/InlineConstantTests.cs
@@ -1,0 +1,32 @@
+﻿using System.Linq;
+using NUnit.Framework;
+
+namespace ULox.Core.Tests
+{
+    [TestFixture]
+    public class InlineConstantTests : EngineTestBase
+    {
+        [Test]
+        public void Constants_WhenExpressableAsByteCodeValue_ShouldBeLimited()
+        {
+            testEngine.Run(@"
+var a = 1;
+a = 2;
+a = true;
+a = null;
+a = 1/2;
+a = 0.5;
+a = 0.25;
+a = 0.75;
+a = 0.3333333333333333;
+a = -0.8;
+a = -5000.5;
+a = 2000;
+");
+
+            Assert.AreEqual(
+                1,
+                testEngine.MyEngine.Context.Program.CompiledScripts.Sum(x => x.AllChunks.Sum(x => x.Constants.Count)) );
+        }
+    }
+}

--- a/ulox/ulox.core.tests/OptimiserTests.cs
+++ b/ulox/ulox.core.tests/OptimiserTests.cs
@@ -21,7 +21,7 @@ namespace ULox.Core.Tests
             testEngine.Run("print (1+2);");
 
             Assert.AreEqual("3", testEngine.InterpreterResult);
-            Assert.AreEqual(6, testEngine.MyEngine.Context.Program.CompiledScripts[0].TopLevelChunk.Instructions.Count);
+            Assert.AreEqual(7, testEngine.MyEngine.Context.Program.CompiledScripts[0].TopLevelChunk.Instructions.Count);
         }
 
         [Test]
@@ -32,7 +32,7 @@ label unused;
 print (1+2);");
 
             Assert.AreEqual("3", testEngine.InterpreterResult);
-            StringAssert.Contains("Instructions: 10 -> 6", _opt.OptimisationReporter.GetReport().GenerateStringReport());
+            StringAssert.Contains("Instructions: 10 -> 7", _opt.OptimisationReporter.GetReport().GenerateStringReport());
         }
 
         [Test]
@@ -44,7 +44,7 @@ label unused;
 print (1+2);");
 
             Assert.AreEqual("33", testEngine.InterpreterResult);
-            StringAssert.Contains("Instructions: 16 -> 11", _opt.OptimisationReporter.GetReport().GenerateStringReport());
+            StringAssert.Contains("Instructions: 16 -> 13", _opt.OptimisationReporter.GetReport().GenerateStringReport());
         }
 
         [Test]
@@ -58,7 +58,7 @@ label skip;
 print(1+2);");
 
             Assert.AreEqual("3", testEngine.InterpreterResult);
-            StringAssert.Contains("Instructions: 16 -> 6", _opt.OptimisationReporter.GetReport().GenerateStringReport());
+            StringAssert.Contains("Instructions: 16 -> 7", _opt.OptimisationReporter.GetReport().GenerateStringReport());
         }
 
         [Test]
@@ -71,7 +71,7 @@ label skip;
 print(1+2);");
 
             Assert.AreEqual("3", testEngine.InterpreterResult);
-            StringAssert.Contains("Instructions: 15 -> 6", _opt.OptimisationReporter.GetReport().GenerateStringReport());
+            StringAssert.Contains("Instructions: 15 -> 7", _opt.OptimisationReporter.GetReport().GenerateStringReport());
         }
 
         [Test]
@@ -83,7 +83,7 @@ label skip;
 print(1+2);");
 
             Assert.AreEqual("3", testEngine.InterpreterResult);
-            StringAssert.Contains("Instructions: 11 -> 6", _opt.OptimisationReporter.GetReport().GenerateStringReport());
+            StringAssert.Contains("Instructions: 11 -> 7", _opt.OptimisationReporter.GetReport().GenerateStringReport());
         }
         
         [Test]
@@ -99,7 +99,7 @@ print (c);
 }");
 
             Assert.AreEqual("3", testEngine.InterpreterResult);
-            StringAssert.Contains("Instructions: 15 -> 9", _opt.OptimisationReporter.GetReport().GenerateStringReport());
+            StringAssert.Contains("Instructions: 15 -> 10", _opt.OptimisationReporter.GetReport().GenerateStringReport());
         }
 
         [Test]
@@ -115,7 +115,7 @@ print (c);
 }");
 
             Assert.AreEqual("False", testEngine.InterpreterResult);
-            StringAssert.Contains("Instructions: 15 -> 9", _opt.OptimisationReporter.GetReport().GenerateStringReport());
+            StringAssert.Contains("Instructions: 15 -> 10", _opt.OptimisationReporter.GetReport().GenerateStringReport());
         }
 
         [Test]
@@ -132,7 +132,7 @@ print (d);
 }");
 
             Assert.AreEqual("0", testEngine.InterpreterResult);
-            StringAssert.Contains("Instructions: 18 -> 10", _opt.OptimisationReporter.GetReport().GenerateStringReport());
+            StringAssert.Contains("Instructions: 18 -> 12", _opt.OptimisationReporter.GetReport().GenerateStringReport());
         }
 
         [Test]
@@ -163,7 +163,7 @@ print (l[index]);
 }");
 
             Assert.AreEqual("0", testEngine.InterpreterResult);
-            StringAssert.Contains("Instructions: 26 -> 20", _opt.OptimisationReporter.GetReport().GenerateStringReport());
+            StringAssert.Contains("Instructions: 26 -> 21", _opt.OptimisationReporter.GetReport().GenerateStringReport());
         }
 
         [Test]
@@ -469,7 +469,7 @@ var t = T(1,2);");
         DoIt();");
 
             Assert.AreEqual("1020304050111213141512122232425231323334353414243444545", testEngine.InterpreterResult);
-            StringAssert.Contains("Instructions: 59 -> 41", _opt.OptimisationReporter.GetReport().GenerateStringReport());
+            StringAssert.Contains("Instructions: 59 -> 42", _opt.OptimisationReporter.GetReport().GenerateStringReport());
         }
 
         [Test]
@@ -489,7 +489,7 @@ var t = T(1,2);");
 
             Assert.AreEqual("3", testEngine.InterpreterResult);
             //a b and c all go to same loc, so should be removed
-            StringAssert.Contains("Instructions: 27 -> 11", _opt.OptimisationReporter.GetReport().GenerateStringReport());
+            StringAssert.Contains("Instructions: 27 -> 12", _opt.OptimisationReporter.GetReport().GenerateStringReport());
             StringAssert.Contains("Labels: 6 -> 2", _opt.OptimisationReporter.GetReport().GenerateStringReport());
         }
 
@@ -510,7 +510,7 @@ var t = T(1,2);");
 
             Assert.AreEqual("3", testEngine.InterpreterResult);
             //a b and c all go to same loc, so should be removed
-            StringAssert.Contains("Instructions: 27 -> 11", _opt.OptimisationReporter.GetReport().GenerateStringReport());
+            StringAssert.Contains("Instructions: 27 -> 12", _opt.OptimisationReporter.GetReport().GenerateStringReport());
             StringAssert.Contains("Labels: 6 -> 2", _opt.OptimisationReporter.GetReport().GenerateStringReport());
         }
 
@@ -828,7 +828,7 @@ var t = T(1,2);");
 
             Assert.AreEqual("", testEngine.InterpreterResult);
             Assert.IsTrue(testEngine.MyEngine.Context.Vm.TestRunner.AllPassed);
-            StringAssert.Contains("Instructions: 813 -> 497", _opt.OptimisationReporter.GetReport().GenerateStringReport());
+            StringAssert.Contains("Instructions: 813 -> 518", _opt.OptimisationReporter.GetReport().GenerateStringReport());
         }
 
         [Test]
@@ -927,7 +927,7 @@ DoSomeVecMath();
 ");
 
             Assert.AreEqual("1,2,3,4,0,0,4,6,-2,-2,2,3,11,5,0.6,0.8", testEngine.InterpreterResult);
-            StringAssert.Contains("Instructions: 119 -> 86", _opt.OptimisationReporter.GetReport().GenerateStringReport());
+            StringAssert.Contains("Instructions: 119 -> 89", _opt.OptimisationReporter.GetReport().GenerateStringReport());
         }
     }
 }

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compiler.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compiler.cs
@@ -17,8 +17,7 @@ namespace ULox
     {
         Null,
         Bool,
-        Byte,
-        Bytes,
+        Short,
     }
 
     public interface ICompilette
@@ -202,11 +201,12 @@ namespace ULox
             var (line, _) = TokenIterator.GetLineAndCharacter(TokenIterator.PreviousToken.StringSourceIndex);
             CurrentChunk.WritePacket(packet, line);
         }
+
         public void EmitNULL()
             => EmitPacket(new ByteCodePacket(OpCode.PUSH_VALUE, (byte)PushValueOpType.Null));
 
-        public void EmitPushValue(byte b)
-            => EmitPacket(new ByteCodePacket(OpCode.PUSH_VALUE, (byte)PushValueOpType.Byte, b));
+        public void EmitPushValue(short s)
+            => EmitPacket(new ByteCodePacket(OpCode.PUSH_VALUE, (byte)PushValueOpType.Short, s));
 
         public void EmitPushValue(bool b)
             => EmitPacket(new ByteCodePacket(OpCode.PUSH_VALUE, (byte)PushValueOpType.Bool, (byte)(b ? 1 : 0)));
@@ -534,12 +534,12 @@ namespace ULox
             // Create the function object.
             var comp = CurrentCompilerState;   //we need this to mark upvalues
             var function = EndCompile();
-            EmitPacket(new ByteCodePacket(OpCode.CLOSURE, new ByteCodePacket.ClosureDetails(ClosureType.Closure, CurrentChunk.AddConstant(Value.New(function)), (byte)function.UpvalueCount)));
+            EmitPacket(new ByteCodePacket(new ByteCodePacket.ClosureDetails(ClosureType.Closure, CurrentChunk.AddConstant(Value.New(function)), (byte)function.UpvalueCount)));
 
             for (int i = 0; i < function.UpvalueCount; i++)
             {
                 EmitPacket(
-                    new ByteCodePacket(OpCode.CLOSURE, new ByteCodePacket.ClosureDetails(
+                    new ByteCodePacket(new ByteCodePacket.ClosureDetails(
                     ClosureType.UpValueInfo,
                     comp.upvalues[i].isLocal ? (byte)1 : (byte)0,
                     comp.upvalues[i].index)));

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/EnumTypeDeclarationCompliette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/EnumTypeDeclarationCompliette.cs
@@ -57,7 +57,7 @@ namespace ULox
                 else
                 {
                     SetMode(compiler, Mode.Auto);
-                    compiler.EmitPushValue((byte)++_previousNumber);
+                    compiler.EmitPushValue((short)++_previousNumber);
                 }
 
 

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TestcaseCompillette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TestcaseCompillette.cs
@@ -42,7 +42,7 @@
                     compiler.DeclareAndDefineCustomVariable(TestDataRowVarName);
                     compiler.EmitNULL();
                     compiler.DeclareAndDefineCustomVariable(TestDataIndexVarName);
-                    compiler.EmitPushValue((byte)0);
+                    compiler.EmitPushValue(0);
                     compiler.Expression();
                     var res = compiler.ResolveLocal(TestDataSourceVarName);
                     testDataSourceLocalId = (byte)res;

--- a/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TypeCompilette.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/Compilettes/TypeCompilette.cs
@@ -77,7 +77,7 @@
             var chunk = compiler.EndCompile();
             if (EmitClosureCallAtEnd)
             {
-                compiler.EmitPacket(new ByteCodePacket(OpCode.CLOSURE, new ByteCodePacket.ClosureDetails(ClosureType.Closure, compiler.CurrentChunk.AddConstant(Value.New(chunk)), (byte)chunk.UpvalueCount)));
+                compiler.EmitPacket(new ByteCodePacket(new ByteCodePacket.ClosureDetails(ClosureType.Closure, compiler.CurrentChunk.AddConstant(Value.New(chunk)), (byte)chunk.UpvalueCount)));
                 compiler.EmitPacket(new ByteCodePacket(OpCode.CALL, 0, 0, 0));
                 compiler.EmitPop();
             }

--- a/ulox/ulox.core/Package/Runtime/Compiler/DoubleToQuotient.cs
+++ b/ulox/ulox.core/Package/Runtime/Compiler/DoubleToQuotient.cs
@@ -1,0 +1,78 @@
+﻿using System;
+
+namespace ULox
+{
+    public static class DoubleToQuotient
+    {
+        // adapted from https://rosettacode.org/wiki/Convert_decimal_number_to_rational#C++
+        public static (bool isPossible, int nume, uint denom) ToQuotient(double num, int decimalPlances)
+        {
+            if (num == 0.0)
+            {
+                return (true, 0, 1);
+            }
+            var isNegative = num < 0.0;
+            if (isNegative)
+            {
+                num = -num;
+            }
+
+            double epsilon = 1.0 / Math.Pow(10, decimalPlances);
+
+            if (Math.Abs(num - Math.Round(num)) < epsilon)
+            {
+                return (true, (int)Math.Round(num), 1);
+            }
+
+            ulong a = 0;
+            ulong b = 1;
+            ulong c = (ulong)Math.Ceiling(num);
+            ulong d = 1;
+            ulong auxiliary_1 = uint.MaxValue / 2;
+
+            while (c < auxiliary_1 && d < auxiliary_1)
+            {
+                var auxiliary_2 = (a + c) / (double)(b + d);
+
+                if (Math.Abs(num - auxiliary_2) < epsilon)
+                {
+                    break;
+                }
+
+                if (num > auxiliary_2)
+                {
+                    a = a + c;
+                    b = b + d;
+                }
+                else
+                {
+                    c = a + c;
+                    d = b + d;
+                }
+            }
+
+            var divisor = GCD((a + c), (b + d));
+            var numeUL = (a + c) / divisor;
+            var denomUL = (b + d) / divisor;
+            if (numeUL > uint.MaxValue || denomUL > uint.MaxValue)
+            {
+                return (false, 0, 0);
+            }
+            return (true, (isNegative ? -1 : 1 ) * (int)numeUL, (uint)denomUL);
+        }
+
+        //  https://stackoverflow.com/questions/18541832/c-sharp-find-the-greatest-common-divisor
+        private static ulong GCD(ulong a, ulong b)
+        {
+            while (a != 0 && b != 0)
+            {
+                if (a > b)
+                    a %= b;
+                else
+                    b %= a;
+            }
+
+            return a | b;
+        }
+    }
+}

--- a/ulox/ulox.core/Package/Runtime/Engine/Disassembler.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/Disassembler.cs
@@ -204,7 +204,7 @@ namespace ULox
                     break;
                 case TestOpType.TestCase:
                     PrintLabel(packet.testOpDetails.LabelId);
-                break;
+                    break;
                 case TestOpType.CaseStart:
                 case TestOpType.CaseEnd:
                 {
@@ -259,16 +259,19 @@ namespace ULox
                 case PushValueOpType.Bool:
                     stringBuilder.Append($"({packet.b2 == 1})");
                     break;
-                case PushValueOpType.Byte:
-                    stringBuilder.Append($"({packet.b2})");
-                    break;
-                case PushValueOpType.Bytes:
-                    stringBuilder.Append($"({packet.b2},{packet.b3})");
+                case PushValueOpType.Short:
+                    stringBuilder.Append($"({packet.ShortValue})");
                     break;
                 }
             }
             break;
-
+            case OpCode.PUSH_QUOTIENT:
+            {
+                var nume = packet.quotientDetails.GetNumeratorShort();
+                var val = nume / (double)packet.quotientDetails.denom;
+                stringBuilder.Append($"{nume} / {packet.quotientDetails.denom} ({val})");
+            }
+            break;
             case OpCode.GET_LOCAL:
             {
                 var b1 = packet.b1;

--- a/ulox/ulox.core/Package/Runtime/Engine/VM.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/VM.cs
@@ -343,16 +343,18 @@ namespace ULox
                     case PushValueOpType.Bool:
                         Push(Value.New(packet.b2 == 1));
                         break;
-                    case PushValueOpType.Byte:
-                        Push(Value.New(packet.b2));
-                        break;
-                    case PushValueOpType.Bytes:
-                        Push(Value.New(packet.b2));
-                        Push(Value.New(packet.b3));
+                    case PushValueOpType.Short:
+                        Push(Value.New(packet.ShortValue));
                         break;
                     default:
                         break;
                     }
+                }
+                break;
+                case OpCode.PUSH_QUOTIENT:
+                {
+                    var val = packet.quotientDetails.GetNumeratorShort() / (double)packet.quotientDetails.denom;
+                    Push(Value.New(val));
                 }
                 break;
 

--- a/ulox/ulox.core/Package/Runtime/Optimiser/OptimiserCollapseOpsPass.cs
+++ b/ulox/ulox.core/Package/Runtime/Optimiser/OptimiserCollapseOpsPass.cs
@@ -21,10 +21,6 @@ namespace ULox
         {
             switch (packet.OpCode)
             {
-            case OpCode.PUSH_VALUE:
-                if (packet.b1 == (byte)PushValueOpType.Byte)
-                    _byteToProcess.Add(inst);
-                break;
             case OpCode.GET_LOCAL:
                 if (packet.b2 == Optimiser.NOT_LOCAL_BYTE)   //for now only optimise single byte locals
                     _getLocals.Add(inst);
@@ -39,26 +35,6 @@ namespace ULox
 
         public PassCompleteRequest Complete(Optimiser optimiser, Chunk chunk)
         {
-            for (int i = 0; i < _byteToProcess.Count - 1; i++)
-            {
-                var inst1 = _byteToProcess[i];
-                var inst2 = _byteToProcess[i + 1];
-                if (inst2 - inst1 != 1
-                    || chunk.Labels.Any(x => x.Value == inst1))
-                    continue;
-
-                var packet1 = chunk.Instructions[inst1];
-                var packet2 = chunk.Instructions[inst2];
-                if (packet1.OpCode == OpCode.PUSH_VALUE && packet2.OpCode == OpCode.PUSH_VALUE)
-                {
-                    var newPacket = new ByteCodePacket(OpCode.PUSH_VALUE, (byte)PushValueOpType.Bytes, packet1.b2, packet2.b2);
-                    chunk.Instructions[inst1] = newPacket;
-                    optimiser.AddToRemove(chunk, inst2);
-                }
-
-                i++;
-            }
-
             for (int i = 0; i < _getLocals.Count - 1; i++)
             {
                 var inst1 = _getLocals[i];


### PR DESCRIPTION
Add PUSH_QUOTIENT.

Reworks the existing push value to store shorts not just byte(s)
Stores short / byte quotients so we can avoid having named constants for things like 0.5 or 0.3(3) or -5000.5.

close #271