### PR TITLE
Update replaces an lhs with an rhs null

### DIFF
--- a/ulox/ulox.core.tests/UpdateTests.cs
+++ b/ulox/ulox.core.tests/UpdateTests.cs
@@ -142,7 +142,24 @@ print(foo meets foo2);
 
             StringAssert.StartsWith("22False", testEngine.InterpreterResult);
         }
-        
+
+        [Test]
+        public void Update_WhenMatchNameNull_ShouldUpdateValue()
+        {
+            testEngine.Run(@"
+var foo = {a=1, b=2,};
+var foo2 = {a=null, c=3,};
+
+foo = foo update foo2;
+print(foo.a);
+print(foo.b);
+print(foo meets foo2);
+"
+            );
+
+            StringAssert.StartsWith("null2False", testEngine.InterpreterResult);
+        }
+
         [Test]
         public void Update_WhenPartialHierarchyMatch_ShouldUpdateValue()
         {

--- a/ulox/ulox.core/Package/Runtime/Engine/VM.cs
+++ b/ulox/ulox.core/Package/Runtime/Engine/VM.cs
@@ -58,8 +58,20 @@ namespace ULox
 
         public InterpreterResult PushCallFrameAndRun(Value func, byte args)
         {
-            PushCallFrameFromValue(func, args);
-            return Run();
+            try
+            {
+                PushCallFrameFromValue(func, args);
+                return Run();
+            }
+            catch(ULox.UloxException uloxEx)
+            {
+                throw uloxEx;
+            }
+            catch (System.Exception e)
+            {
+                ThrowRuntimeException($"Unhandled exception '{e}'");
+            }
+            return InterpreterResult.OK;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/ulox/ulox.core/Package/Runtime/Types/Value.cs
+++ b/ulox/ulox.core/Package/Runtime/Types/Value.cs
@@ -322,10 +322,11 @@ namespace ULox
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static Value UpdateFrom(Value lhs, Value rhs, Vm vm)
         {
-            if (!lhs.IsNull() && rhs.type != lhs.type)
-            {
+            if (!lhs.IsNull() && rhs.type != lhs.type && rhs.type != ValueType.Null)
                 return lhs;
-            }
+
+            if (rhs.IsNull())
+                return rhs;
 
             switch (lhs.type)
             {


### PR DESCRIPTION
Previously a type mismatch would result in lhs remaining. Now a provided rhs null object will replace the lhs.